### PR TITLE
Refactor MCP tools to use conversational names and random File Ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,15 +320,15 @@ For backwards compatibility, the original separate MCP server is still available
 ./run_with_mcp.sh
 ```
 
-### MCP Server Features
+### MCP Server Tools
 
-The MCP server provides the following tools for AI assistants:
+The MCP server provides conversationally named tools for AI assistants:
 
-- **`create_markdown_file`**: Create new markdown files with auto-numbering
-- **`list_markdown_files`**: List all existing markdown files  
-- **`read_markdown_file`**: Read content of specific files
-- **`update_markdown_file`**: Append or replace file content
-- **`delete_markdown_file`**: Remove markdown files
+- **`show_content`**: Generate new markdown content. The server picks a random File Id ending in `.md`, stores the content, and returns the identifier so the assistant can reference it later.
+- **`list_content`**: List every markdown entry currently available along with helpful metadata.
+- **`view_content`**: Retrieve the content for a specific File Id that was previously returned by `show_content`.
+- **`update_content`**: Append to or completely replace an existing entry by supplying its File Id.
+- **`remove_content`**: Delete an entry using its File Id when it is no longer needed.
 
 ### AI Assistant Setup
 

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -6,11 +6,11 @@
       "cwd": ".",
       "description": "MCP server for managing markdown files in the live view system",
       "capabilities": [
-        "create_markdown_file",
-        "list_markdown_files", 
-        "read_markdown_file",
-        "update_markdown_file",
-        "delete_markdown_file"
+        "show_content",
+        "list_content",
+        "view_content",
+        "update_content",
+        "remove_content"
       ]
     }
   }

--- a/test_mcp.py
+++ b/test_mcp.py
@@ -4,17 +4,16 @@ Test script for the MCP server functionality.
 """
 
 import asyncio
-import json
-import subprocess
 import sys
 from pathlib import Path
 
+
 async def test_mcp_server():
     """Test the MCP server by simulating MCP client requests."""
-    
+
     print("🧪 Testing MCP Server Functionality")
     print("=" * 50)
-    
+
     # Test data
     test_content = """# Test Markdown File
 
@@ -45,8 +44,8 @@ graph TD
 
 This file demonstrates the MCP server's ability to create markdown files that integrate seamlessly with the live view system.
 """
-    
-    # Prepare test scenarios
+
+    # Prepare test scenarios (documentation only, not executed)
     tests = [
         {
             "name": "List Tools",
@@ -54,110 +53,97 @@ This file demonstrates the MCP server's ability to create markdown files that in
             "params": {}
         },
         {
-            "name": "List Files (initially empty)",
-            "method": "tools/call", 
+            "name": "List Content (initially empty)",
+            "method": "tools/call",
             "params": {
-                "name": "list_markdown_files",
+                "name": "list_content",
                 "arguments": {}
             }
         },
         {
-            "name": "Create Test File",
+            "name": "Show Test Content",
             "method": "tools/call",
             "params": {
-                "name": "create_markdown_file",
+                "name": "show_content",
                 "arguments": {
-                    "filename": "mcp-test",
+                    "title": "Test Plan",
                     "content": test_content
                 }
             }
         },
         {
-            "name": "List Files (after creation)",
+            "name": "List Content (after creation)",
             "method": "tools/call",
             "params": {
-                "name": "list_markdown_files", 
+                "name": "list_content",
                 "arguments": {}
             }
         },
-        {
-            "name": "Read Created File",
-            "method": "tools/call",
-            "params": {
-                "name": "read_markdown_file",
-                "arguments": {
-                    "filename": "mcp-test"
-                }
-            }
-        },
-        {
-            "name": "Update File (append)",
-            "method": "tools/call",
-            "params": {
-                "name": "update_markdown_file",
-                "arguments": {
-                    "filename": "mcp-test",
-                    "content": "\n## Update Test\n\nThis content was appended via MCP update!",
-                    "mode": "append"
-                }
-            }
-        }
     ]
-    
+
     print("Starting MCP server for testing...")
-    
+
     # For this test, we'll create files directly and verify they exist
     # since setting up a full MCP client is complex
-    
+
     try:
         from mcp_server import MarkdownMCPServer
-        
+
         # Create MCP server instance
         server = MarkdownMCPServer("markdown")
-        
+
         print("✅ MCP Server instance created successfully")
-        
-        # Test create file
-        result = await server._create_markdown_file("mcp-test", test_content)
-        print(f"✅ Create file test: {result.content[0].text}")
-        
+
+        # Test create file using the new show_content flow
+        create_result = await server._show_content(test_content, title="Test File")
+        create_message = create_result.content[0].text
+        print(f"✅ Show content test: {create_message}")
+
+        file_id = None
+        for line in create_message.splitlines():
+            if line.strip().lower().startswith("file id:"):
+                file_id = line.split(":", 1)[1].strip()
+                break
+
+        if not file_id:
+            print("❌ Could not parse File Id from response")
+            return False
+
         # Test list files
-        result = await server._list_markdown_files()
-        print(f"✅ List files test: Found files in directory")
-        
+        result = await server._list_content()
+        print("✅ List content test: Found files in directory")
+
         # Test read file
-        result = await server._read_markdown_file("mcp-test") 
-        print(f"✅ Read file test: Successfully read file content")
-        
+        result = await server._view_content(file_id)
+        print("✅ View content test: Successfully read file content")
+
         # Test update file
-        result = await server._update_markdown_file("mcp-test", "\n## MCP Update Test\n\nThis was appended via MCP!", "append")
-        print(f"✅ Update file test: {result.content[0].text}")
-        
+        result = await server._update_content(file_id, "## MCP Update Test\n\nThis was appended via MCP!", "append")
+        print(f"✅ Update content test: {result.content[0].text}")
+
         # Verify the file exists in the filesystem
         markdown_dir = Path("markdown")
-        created_files = list(markdown_dir.glob("*mcp-test.md"))
-        
-        if created_files:
-            print(f"✅ File verification: Found {len(created_files)} files matching pattern")
-            for file_path in created_files:
-                print(f"   - {file_path.name}")
-                # Check file size
-                size = file_path.stat().st_size
-                print(f"   - Size: {size} bytes")
+        target_path = markdown_dir / file_id
+
+        if target_path.exists():
+            print("✅ File verification: Created File Id exists on disk")
+            size = target_path.stat().st_size
+            print(f"   - {file_id} ({size} bytes)")
         else:
-            print("❌ File verification: No files found")
-        
+            print("❌ File verification: File Id not found on disk")
+
         print("\n🎉 MCP Server tests completed successfully!")
         print("\n📝 Next steps:")
         print("1. Start the live view server: python server.py")
         print("2. Open browser to http://localhost:8080")
         print("3. See the MCP-created files in the live view!")
-        
+
     except Exception as e:
         print(f"❌ Error during testing: {e}")
         return False
-    
+
     return True
+
 
 if __name__ == "__main__":
     success = asyncio.run(test_mcp_server())


### PR DESCRIPTION
## Summary
- rename the MCP tool surface to conversational verbs (show_content, list_content, view_content, update_content, remove_content) and keep legacy aliases
- generate random File Ids for new content and reuse them across read/update/delete flows, updating docs and configuration accordingly
- refresh the test scripts to parse returned File Ids and exercise the new tooling flow

## Testing
- python test_mcp.py

------
https://chatgpt.com/codex/tasks/task_e_68dbec6442f48328985a8c170fdeeeeb