### PR TITLE
Run FastMCP HTTP server on separate port

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ watchdog>=3.0.0
 fastmcp>=2.12.0
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
+uvicorn>=0.24.0


### PR DESCRIPTION
## Summary
- run the FastMCP HTTP transport on its own Uvicorn server with configurable host/port
- expose the Starlette app for testing and adjust the unified server tests to exercise the MCP HTTP API directly
- add uvicorn to the Python requirements to support the dedicated FastMCP server

## Testing
- pytest tests -q

------
https://chatgpt.com/codex/tasks/task_e_68dddc3157348328bb301c05daade2e8