### PR TITLE
Add Excalidraw dark theme styling to unified index template

### DIFF
--- a/templates/unified_index.html
+++ b/templates/unified_index.html
@@ -51,6 +51,91 @@
             flex: 1;
         }
 
+        /* Excalidraw dark theme variables (sourced from upstream theme.scss) */
+        .excalidraw.theme--dark.theme--dark-background-none {
+            background: none;
+        }
+
+        .excalidraw.theme--dark {
+            --theme-filter: invert(93%) hue-rotate(180deg);
+            --button-destructive-bg-color: #5a0000;
+            --button-destructive-color: #ffa8a8;
+            --button-gray-1: #363636;
+            --button-gray-2: #272727;
+            --button-gray-3: #222;
+            --button-special-active-bg-color: #204624;
+            --dialog-border-color: var(--color-gray-80);
+            --dropdown-icon: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="292.4" height="292.4" viewBox="0 0 292 292"><path fill="%23ced4da" d="M287 197L159 69c-4-3-8-5-13-5s-9 2-13 5L5 197c-3 4-5 8-5 13s2 9 5 13c4 4 8 5 13 5h256c5 0 9-1 13-5s5-8 5-13-1-9-5-13z"/></svg>');
+            --focus-highlight-color: #228be6;
+            --icon-green-fill-color: #69db7c;
+            --default-bg-color: #121212;
+            --input-bg-color: #121212;
+            --input-border-color: #2e2e2e;
+            --input-hover-bg-color: #181818;
+            --input-label-color: #e9ecef;
+            --island-bg-color: #232329;
+            --keybinding-color: var(--color-gray-60);
+            --link-color: #4dabf7;
+            --overlay-bg-color: rgba(52, 58, 64, 0.12);
+            --popup-secondary-bg-color: #222;
+            --popup-text-color: #ced4da;
+            --popup-text-inverted-color: #2c2c2c;
+            --select-highlight-color: #4dabf7;
+            --shadow-island: 0px 0px 0.9310142993927002px 0px rgba(0, 0, 0, 0.17),
+                0px 0px 3.1270833015441895px 0px rgba(0, 0, 0, 0.08),
+                0px 7px 14px 0px rgba(0, 0, 0, 0.05);
+            --modal-shadow: 0px 100px 80px rgba(0, 0, 0, 0.07),
+                0px 41.7776px 33.4221px rgba(0, 0, 0, 0.0503198),
+                0px 22.3363px 17.869px rgba(0, 0, 0, 0.0417275),
+                0px 12.5216px 10.0172px rgba(0, 0, 0, 0.035),
+                0px 6.6501px 5.32008px rgba(0, 0, 0, 0.0282725),
+                0px 2.76726px 2.21381px rgba(0, 0, 0, 0.0196802);
+            --avatar-border-color: var(--color-gray-85);
+            --scrollbar-thumb: #343a40;
+            --scrollbar-thumb-hover: #495057;
+            --color-slider-track: hsl(244, 23%, 39%);
+            --color-selection: #3530c4;
+            --color-icon-white: var(--color-gray-90);
+            --color-primary: #a8a5ff;
+            --color-primary-darker: #b2aeff;
+            --color-primary-darkest: #beb9ff;
+            --color-primary-light: #4f4d6f;
+            --color-primary-light-darker: #43415e;
+            --color-primary-hover: #bbb8ff;
+            --color-disabled: var(--color-gray-70);
+            --color-text-warning: var(--color-gray-80);
+            --color-danger: #ffa8a5;
+            --color-danger-dark: #672120;
+            --color-danger-darker: #8f2625;
+            --color-danger-darkest: #ac2b29;
+            --color-danger-text: #fbcbcc;
+            --color-danger-background: #fbcbcc;
+            --color-danger-icon-background: #672120;
+            --color-danger-color: #261919;
+            --color-danger-icon-color: #fbcbcc;
+            --color-warning-background: var(--color-warning);
+            --color-warning-icon-background: var(--color-warning-dark);
+            --color-warning-color: var(--color-gray-80);
+            --color-warning-icon-color: var(--color-gray-80);
+            --color-muted: var(--color-gray-80);
+            --color-muted-darker: var(--color-gray-60);
+            --color-muted-darkest: var(--color-gray-20);
+            --color-muted-background: var(--color-gray-40);
+            --color-muted-background-darker: var(--color-gray-20);
+            --color-logo-text: #e2dfff;
+            --color-surface-high: #2e2d39;
+            --color-surface-low: hsl(240, 8%, 15%);
+            --color-surface-mid: hsl(240 6% 10%);
+            --color-surface-lowest: hsl(0, 0%, 7%);
+            --color-on-surface: #e3e3e8;
+            --color-brand-hover: #bbb8ff;
+            --color-on-primary-container: #e0dfff;
+            --color-surface-primary-container: #403e6a;
+            --color-brand-active: #d0ccff;
+            --color-border-outline: #8e8d9c;
+            --color-border-outline-variant: #46464f;
+        }
+
         .container {
             max-width: 1200px;
             margin: 0 auto;


### PR DESCRIPTION
## Summary
- add the upstream Excalidraw dark theme CSS variables to the unified template so embedded boards inherit the dark palette

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de2c8b40848328977346d9e43e17ef