### PR TITLE
Fix Excalidraw asset loading

### DIFF
--- a/templates/print_view.html
+++ b/templates/print_view.html
@@ -112,7 +112,13 @@
     <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.22.2/build/vega-embed.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0.17.4/dist/excalidraw.production.min.js" defer></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0.18.0/dist/prod/index.css">
+    <script type="module">
+        import * as ExcalidrawLib from 'https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0.18.0/dist/prod/index.js';
+
+        // Preserve the existing initialization flow by publishing the module globally.
+        window.ExcalidrawLib = ExcalidrawLib;
+    </script>
     <script>
         window.__PRINT_DATA__ = __PRINT_DATA__;
     </script>

--- a/templates/unified_index.html
+++ b/templates/unified_index.html
@@ -529,10 +529,15 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.9.1/mermaid.min.js" defer=""></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" defer=""></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0.17.4/dist/excalidraw.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0.18.0/dist/prod/index.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" defer=""></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" defer=""></script>
-    <script src="https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0.17.4/dist/excalidraw.production.min.js" defer=""></script>
+    <script type="module">
+        import * as ExcalidrawLib from 'https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0.18.0/dist/prod/index.js';
+
+        // Expose the module on window so the existing initialization logic can continue to poll for it.
+        window.ExcalidrawLib = ExcalidrawLib;
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/vega@5.25.0/build/vega.min.js" defer=""></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-lite@5.15.0/build/vega-lite.min.js" defer=""></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.22.2/build/vega-embed.min.js" defer=""></script>


### PR DESCRIPTION
## Summary
- switch the Excalidraw stylesheet to the v0.18.0 CDN path so the dark theme assets resolve
- load the new module build and expose it on `window` to keep the existing initialization code working in both views

## Testing
- not run (front-end change only)


------
https://chatgpt.com/codex/tasks/task_e_68de304c56988328806dd562e89727a5