### PR TITLE
Keep layout panels anchored to the viewport

### DIFF
--- a/templates/unified_index.html
+++ b/templates/unified_index.html
@@ -50,6 +50,11 @@
             display: none !important;
         }
 
+        html,
+        body {
+            height: 100%;
+        }
+
         body {
             margin: 0;
             font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, "Roboto", sans-serif;
@@ -57,7 +62,9 @@
             color: #c9d1d9;
             display: flex;
             flex-direction: column;
-            min-height: 100vh;
+            min-height: 0;
+            height: 100%;
+            overflow: hidden;
         }
 
         a {
@@ -70,6 +77,7 @@
             gap: 0;
             padding: 0;
             min-height: 0;
+            height: 100%;
             overflow: hidden;
             flex: 1 1 auto;
         }
@@ -106,7 +114,8 @@
             background: #161b22;
             border: 1px solid #30363d;
             border-radius: 0;
-            min-height: 60vh;
+            min-height: 0;
+            height: 100%;
             overflow: hidden;
         }
 
@@ -188,6 +197,7 @@
             padding: 24px;
             overflow-y: auto;
             flex: 1;
+            min-height: 0;
         }
 
         .content-area.hidden {
@@ -313,6 +323,7 @@
             padding: 24px;
             overflow: hidden;
             min-height: 320px;
+            height: 100%;
         }
 
         .editor-container.visible {
@@ -374,7 +385,8 @@
             border-radius: 0;
             padding: 0;
             gap: 0;
-            height: 100vh;
+            height: 100%;
+            min-height: 0;
             overflow: hidden;
             transition: box-shadow 0.2s ease;
         }
@@ -388,6 +400,7 @@
             flex-direction: column;
             gap: 0;
             height: 100%;
+            min-height: 0;
             opacity: 0;
             pointer-events: none;
             transition: opacity 0.2s ease;
@@ -702,6 +715,7 @@
             min-height: 48px;
             max-height: 75vh;
             transition: height 0.15s ease;
+            flex: 0 0 auto;
         }
 
         .terminal-panel.is-collapsed {


### PR DESCRIPTION
## Summary
- make the main layout occupy the full viewport so the terminal panel remains fixed at the bottom
- adjust the viewer and sidebars to stretch within the available height so only their respective content scrollbars move

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df845c7a4c8328bf82f9fa44d25524