### PR TITLE
Fix terminal collapse restores xterm state

### DIFF
--- a/templates/unified_index.html
+++ b/templates/unified_index.html
@@ -3238,21 +3238,38 @@
 
                     if (collapsed) {
                         terminalPanel.style.height = '';
-                    } else {
-                        applyHeight(terminalHeight || clampHeight(terminalPanel.getBoundingClientRect().height || 260));
+                        return;
                     }
+
+                    applyHeight(terminalHeight || clampHeight(terminalPanel.getBoundingClientRect().height || 260));
+
+                    if (terminalPanel) {
+                        const handleTransitionEnd = (event) => {
+                            if (event.target !== terminalPanel || event.propertyName !== 'height') {
+                                return;
+                            }
+                            terminalPanel.removeEventListener('transitionend', handleTransitionEnd);
+                            scheduleTerminalFit();
+                        };
+                        terminalPanel.addEventListener('transitionend', handleTransitionEnd, { once: true });
+                    }
+
+                    const instance = ensureTerminalInstance();
+                    if (instance) {
+                        instance.focus();
+                        if (typeof instance.scrollToBottom === 'function') {
+                            instance.scrollToBottom();
+                        }
+                    }
+
+                    connectTerminal();
                 };
 
                 restoreHeightFromStorage();
 
                 if (terminalToggleButton) {
                     terminalToggleButton.addEventListener('click', () => {
-                        if (terminalCollapsed) {
-                            setCollapsed(false);
-                            applyHeight(terminalHeight || clampHeight(terminalPanel.getBoundingClientRect().height || 260));
-                        } else {
-                            setCollapsed(true);
-                        }
+                        setCollapsed(!terminalCollapsed);
                     });
                 }
 


### PR DESCRIPTION
## Summary
- ensure reopening the terminal panel restores the saved height, refocuses the xterm instance, and reconnects the websocket
- trigger an additional fit when the height transition completes so the terminal regains its full row count

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df9c467e4c83288492822629442318