### PR TITLE
Remove panel toggle buttons from file header

### DIFF
--- a/templates/static/css/app.css
+++ b/templates/static/css/app.css
@@ -175,7 +175,8 @@
         .file-header {
             display: flex;
             align-items: flex-start;
-            justify-content: space-between;
+            justify-content: flex-start;
+            flex-wrap: wrap;
             gap: 16px;
             padding: 16px;
             padding-left: 24px;
@@ -202,43 +203,8 @@
         .file-actions {
             display: flex;
             flex-wrap: wrap;
-            gap: 8px;
-        }
-
-        .layout-toggle-group {
-            display: flex;
             align-items: center;
             gap: 8px;
-            border-right: 1px solid #30363d;
-            padding-right: 12px;
-            margin-right: 12px;
-        }
-
-        .layout-toggle-group button {
-            padding: 10px 12px;
-        }
-
-        .layout-toggle-group button[aria-pressed="false"] {
-            background: transparent;
-            color: #8b949e;
-            border-color: #30363d;
-        }
-
-        .layout-toggle-group button[aria-pressed="false"] .file-button-icon {
-            color: inherit;
-        }
-
-        @media (max-width: 720px) {
-            .layout-toggle-group {
-                width: 100%;
-                justify-content: flex-end;
-                border-right: none;
-                border-bottom: 1px solid #30363d;
-                padding-right: 0;
-                padding-bottom: 8px;
-                margin-right: 0;
-                margin-bottom: 8px;
-            }
         }
 
         .file-actions button {

--- a/templates/unified_index.html
+++ b/templates/unified_index.html
@@ -40,16 +40,6 @@
                     <span id="status-message" class="status-message"></span>
                 </div>
                 <div class="file-actions">
-                    <div class="layout-toggle-group" role="group" aria-label="Toggle panels">
-                        <button id="toggle-toc-panel" type="button" data-panel-toggle="toc" aria-pressed="true"
-                            class="secondary" aria-label="Toggle table of contents panel" title="Toggle table of contents panel">
-                            <i class="fas fa-list file-button-icon" aria-hidden="true"></i>
-                        </button>
-                        <button id="toggle-files-panel" type="button" data-panel-toggle="files" aria-pressed="true"
-                            class="secondary" aria-label="Toggle files panel" title="Toggle files panel">
-                            <i class="fas fa-folder-tree file-button-icon" aria-hidden="true"></i>
-                        </button>
-                    </div>
                     <button id="edit-button" class="" title="Edit the current file"><i
                             class="fas fa-edit file-button-icon"></i></button>
                     <button id="preview-button" class=" hidden" title="Preview the pending changes"><i


### PR DESCRIPTION
## Summary
- remove the panel toggle button group from the file header markup
- left-align the remaining file action buttons by updating the header layout styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e02a30c79c8328b4f64dc22db10527