### PR TITLE
Remove file header status indicator

### DIFF
--- a/templates/static/css/app.css
+++ b/templates/static/css/app.css
@@ -190,16 +190,6 @@
             color: #58a6ff;
         }
 
-        .file-meta {
-            display: flex;
-            flex-direction: column;
-            gap: 6px;
-        }
-
-        .file-meta small {
-            color: #8b949e;
-        }
-
         .file-actions {
             display: flex;
             flex-wrap: wrap;
@@ -241,11 +231,6 @@
             font-size: 0.9rem;
             min-width: 16px;
             display: inline-block;
-        }
-
-        .status-message {
-            color: #ffa657;
-            font-size: 0.9rem;
         }
 
         .content-area {

--- a/templates/static/js/unified_index.js
+++ b/templates/static/js/unified_index.js
@@ -4,7 +4,6 @@ function bootstrap() {
     const content = document.getElementById('content');
     const fileName = document.getElementById('file-name');
     const sidebarPath = document.getElementById('sidebar-path');
-    const statusMessage = document.getElementById('status-message');
     const fileList = document.getElementById('file-list');
     const downloadButton = document.getElementById('download-button');
     const deleteButton = document.getElementById('delete-button');
@@ -1653,7 +1652,8 @@ function bootstrap() {
     }
 
     function setStatus(message) {
-        statusMessage.textContent = message || '';
+        // Status banner removed; keep function to avoid touching callers.
+        void message;
     }
 
     function setConnectionStatus(connected) {

--- a/templates/unified_index.html
+++ b/templates/unified_index.html
@@ -35,10 +35,7 @@
 
         <section class="viewer">
             <header class="file-header">
-                <div class="file-meta">
-                    <h1 id="file-name">Markdown Viewer</h1>
-                    <span id="status-message" class="status-message"></span>
-                </div>
+                <h1 id="file-name">Markdown Viewer</h1>
                 <div class="file-actions">
                     <button id="edit-button" class="" title="Edit the current file"><i
                             class="fas fa-edit file-button-icon"></i></button>


### PR DESCRIPTION
## Summary
- remove the status banner container from the unified viewer header
- strip the unused styles and replace the status update helper with a no-op

## Testing
- python server.py --path markdown --port 8080

------
https://chatgpt.com/codex/tasks/task_e_68e02ca5fde4832893e4d6c35165dd15