### PR TITLE
Add health check script for ensuring app stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,23 @@ If you prefer manual setup or development:
    python start.py
    ```
 
+## ✅ Health Checks
+
+Before shipping changes or packaging a release, you can run the automated health check script to
+confirm the backend still imports cleanly and that the full pytest suite passes:
+
+```bash
+python scripts/ensure_app_works.py
+```
+
+Pass `--skip-tests` if you only want the lightweight syntax compilation step:
+
+```bash
+python scripts/ensure_app_works.py --skip-tests
+```
+
+These checks mirror what CI runs locally, helping catch regressions early.
+
    Or directly:
    ```bash
    python server.py --path /path/to/markdown --port 8080

--- a/scripts/ensure_app_works.py
+++ b/scripts/ensure_app_works.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Run a set of quick health checks to confirm the LiveView app still works."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+# Resolve the repository root so the commands always run from a predictable place.
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_step(command: list[str], description: str) -> None:
+    """Execute a shell command and stream its output."""
+
+    print(f"\n==> {description}")
+    # Using `sys.executable` keeps us inside the same Python environment when needed.
+    result = subprocess.run(command, cwd=ROOT)
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run syntax checks and the pytest suite so we can be confident the "
+            "application still behaves correctly."
+        )
+    )
+    parser.add_argument(
+        "--skip-tests",
+        action="store_true",
+        help="Skip running pytest (useful when you only want the lightweight checks).",
+    )
+    args = parser.parse_args(argv)
+
+    # First make sure all Python modules still compile after recent edits.
+    run_step([sys.executable, "-m", "compileall", "server.py", "components", "tests"], "Checking for syntax errors")
+
+    if not args.skip_tests:
+        # Pytest exercises the HTTP endpoints and verifies the web UI JSON payloads.
+        run_step([sys.executable, "-m", "pytest"], "Running pytest suite")
+
+    print("\n✅ All health checks passed!")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a developer-facing health check script that compiles key modules and runs pytest
- document how to use the new script in the README so contributors can verify the app locally

## Testing
- python scripts/ensure_app_works.py


------
https://chatgpt.com/codex/tasks/task_e_68e118dfa8888328ae57b6ff6af5562d