### PR TITLE
Refactor bootstrap helpers into shared module

### DIFF
--- a/frontend/src/js/app/bootstrap_helpers.js
+++ b/frontend/src/js/app/bootstrap_helpers.js
@@ -1,0 +1,216 @@
+import { renderMarkdown, captureHeadingLocations, getHeadingLocation } from '../viewer/markdown.js';
+
+export function createViewerApi(markdownContext) {
+    return {
+        render(contentValue, options = {}) {
+            renderMarkdown(markdownContext, contentValue, options);
+        },
+        captureHeadings(source) {
+            return captureHeadingLocations(markdownContext, source);
+        },
+        getHeadingLocation(slug) {
+            return getHeadingLocation(markdownContext, slug);
+        },
+        getMarkdownContext() {
+            return markdownContext;
+        },
+    };
+}
+
+export function normaliseFileIndex({ filesValue, treeValue }) {
+    let flat = [];
+    let tree = [];
+
+    if (Array.isArray(filesValue)) {
+        flat = filesValue;
+    } else if (filesValue && Array.isArray(filesValue.files)) {
+        flat = filesValue.files;
+        if (Array.isArray(filesValue.tree)) {
+            tree = filesValue.tree;
+        }
+    }
+
+    if (!tree.length && Array.isArray(treeValue)) {
+        tree = treeValue;
+    }
+
+    if (tree.length && !flat.length) {
+        flat = flattenTree(tree);
+    }
+
+    if (!tree.length && flat.length) {
+        tree = buildTreeFromFlatList(flat);
+    }
+
+    return { files: flat, tree };
+}
+
+export function flattenTree(nodes) {
+    const result = [];
+    if (!Array.isArray(nodes)) {
+        return result;
+    }
+
+    const stack = [...nodes];
+    while (stack.length) {
+        const node = stack.shift();
+        if (!node || typeof node !== 'object') {
+            continue;
+        }
+
+        if (node.type === 'file') {
+            result.push({
+                name: node.name,
+                relativePath: node.relativePath,
+                size: node.size,
+                updated: node.updated,
+            });
+            continue;
+        }
+
+        if (node.type === 'directory' && Array.isArray(node.children)) {
+            stack.unshift(...node.children);
+        }
+    }
+
+    return result;
+}
+
+export function buildTreeFromFlatList(flatList) {
+    if (!Array.isArray(flatList) || !flatList.length) {
+        return [];
+    }
+
+    const root = [];
+    const directoryMap = new Map();
+    directoryMap.set('', root);
+
+    function ensureDirectory(path, name) {
+        if (directoryMap.has(path)) {
+            return directoryMap.get(path);
+        }
+
+        const parentPath = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : '';
+        const parentChildren = directoryMap.get(parentPath) || root;
+        const node = {
+            type: 'directory',
+            name,
+            relativePath: path,
+            children: [],
+        };
+        parentChildren.push(node);
+        directoryMap.set(path, node.children);
+        return node.children;
+    }
+
+    flatList.forEach((file) => {
+        if (!file || typeof file.relativePath !== 'string') {
+            return;
+        }
+
+        const segments = file.relativePath.split('/');
+        const fileName = segments.pop();
+        let currentPath = '';
+        segments.forEach((segment) => {
+            if (!segment) {
+                return;
+            }
+            currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+            ensureDirectory(currentPath, segment);
+        });
+
+        const parentPath = segments.join('/');
+        const parentChildren = directoryMap.get(parentPath) || root;
+        parentChildren.push({
+            type: 'file',
+            name: fileName,
+            relativePath: file.relativePath,
+            size: file.size,
+            updated: file.updated,
+        });
+    });
+
+    sortTree(root);
+    return root;
+}
+
+export function sortTree(nodes) {
+    if (!Array.isArray(nodes)) {
+        return;
+    }
+    nodes.sort((a, b) => {
+        if (a.type === b.type) {
+            return String(a.name || '').localeCompare(String(b.name || ''));
+        }
+        return a.type === 'directory' ? -1 : 1;
+    });
+    nodes.forEach((node) => {
+        if (node.type === 'directory') {
+            sortTree(node.children);
+        }
+    });
+}
+
+export function getCssNumber(rootElement, variableName, fallback) {
+    if (typeof variableName !== 'string' || !variableName) {
+        return typeof fallback === 'number' ? fallback : 0;
+    }
+
+    try {
+        const computed = getComputedStyle(rootElement).getPropertyValue(variableName);
+        const parsed = Number.parseFloat(computed);
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    } catch (error) {
+        console.warn('Failed to read CSS variable', variableName, error);
+    }
+
+    return typeof fallback === 'number' ? fallback : 0;
+}
+
+export function setStatus(message) {
+    // Status banner removed; keep function to avoid touching callers.
+    void message;
+}
+
+export function createSetConnectionStatus(offlineOverlay) {
+    return function setConnectionStatus(connected) {
+        offlineOverlay?.classList.toggle('visible', !connected);
+    };
+}
+
+export function createApplyHasPendingChanges(appState, updateHeader) {
+    return function applyHasPendingChanges(value) {
+        const nextValue = Boolean(value);
+        if (nextValue === appState.hasPendingChanges) {
+            return;
+        }
+        appState.hasPendingChanges = nextValue;
+        document.body.classList.toggle('document-has-pending-changes', appState.hasPendingChanges);
+        updateHeader();
+    };
+}
+
+export function createResetViewToFallback({ sharedContext, viewerApi, editorApi }) {
+    return function resetViewToFallback(options = {}) {
+        const { skipHistory = false } = options || {};
+        if (typeof editorApi?.exitEditMode === 'function') {
+            editorApi.exitEditMode({ restoreContent: false });
+        }
+        sharedContext.setCurrentFile(null, { silent: true });
+        const fallback = sharedContext.fallbackMarkdownFor(
+            sharedContext.getResolvedRootPath() || sharedContext.getOriginalPathArgument() || 'the selected path',
+        );
+        viewerApi.render(fallback, { updateCurrent: true });
+        sharedContext.updateActiveFileHighlight();
+        sharedContext.updateHeader();
+        if (!skipHistory) {
+            sharedContext.updateLocation('', { replace: true });
+        }
+    };
+}
+
+export function fallbackMarkdownFor(path) {
+    return `# No markdown files found\n\nThe directory \`${path}\` does not contain any markdown files yet.`;
+}

--- a/frontend/src/js/files/navigation.js
+++ b/frontend/src/js/files/navigation.js
@@ -1,3 +1,5 @@
+import { buildTreeFromFlatList, fallbackMarkdownFor, normaliseFileIndex } from '../app/bootstrap_helpers.js';
+
 export function initNavigation(context, viewerApi) {
     if (!context) {
         throw new Error('Navigation context is required');
@@ -37,7 +39,7 @@ export function initNavigation(context, viewerApi) {
         if (data?.rootPath) {
             context.setResolvedRootPath(data.rootPath);
         }
-        const updatedIndex = context.normaliseFileIndex({
+        const updatedIndex = normaliseFileIndex({
             filesValue: data?.files,
             treeValue: data?.tree,
         });
@@ -55,7 +57,7 @@ export function initNavigation(context, viewerApi) {
                 context.setCurrentFile(null);
                 state.editorApi?.exitEditMode({ restoreContent: false });
                 viewerApi?.render(
-                    context.fallbackMarkdownFor(
+                    fallbackMarkdownFor(
                         context.getResolvedRootPath() || context.getOriginalPathArgument() || 'the selected path',
                     ),
                     { updateCurrent: true },
@@ -79,7 +81,7 @@ export function initNavigation(context, viewerApi) {
         const tree = context.getFileTree();
         const treeToRender = Array.isArray(tree) && tree.length
             ? tree
-            : context.buildTreeFromFlatList(context.getFiles());
+            : buildTreeFromFlatList(context.getFiles());
 
         if (!treeToRender.length) {
             const empty = document.createElement('li');

--- a/frontend/src/js/unified_index.js
+++ b/frontend/src/js/unified_index.js
@@ -1,11 +1,21 @@
 import './vendor_globals.js';
 import { initLayout } from './viewer/layout.js';
-import { renderMarkdown, captureHeadingLocations, getHeadingLocation } from './viewer/markdown.js';
 import { initEditor } from './editor/editor.js';
 import { initNavigation } from './files/navigation.js';
 import { createAppContext } from './app/context.js';
 import { createRealtimeService } from './services/realtime.js';
 import { createTerminalService } from './services/terminal.js';
+import {
+    createViewerApi,
+    normaliseFileIndex,
+    buildTreeFromFlatList,
+    getCssNumber,
+    setStatus,
+    createSetConnectionStatus,
+    createApplyHasPendingChanges,
+    createResetViewToFallback,
+    fallbackMarkdownFor,
+} from './app/bootstrap_helpers.js';
 
 // Client-side bootstrap logic for the unified markdown viewer UI.
 function bootstrap() {
@@ -58,6 +68,10 @@ function bootstrap() {
 
     appState.currentFile = initialState.selectedFile || null;
     context.initialFileFromLocation = fileFromSearch(window.location.search);
+
+    const setConnectionStatusHandler = createSetConnectionStatus(offlineOverlay);
+    const applyHasPendingChanges = createApplyHasPendingChanges(appState, updateHeader);
+    let resetViewToFallback = () => {};
 
     const sharedContext = {
         elements: {
@@ -134,7 +148,7 @@ function bootstrap() {
         getExpandedDirectories: () => expandedDirectories,
         getKnownDirectories: () => knownDirectories,
         setStatus,
-        setConnectionStatus,
+        setConnectionStatus: (connected) => setConnectionStatusHandler(connected),
         updateHeader() {
             updateHeader();
         },
@@ -150,6 +164,7 @@ function bootstrap() {
         fallbackMarkdownFor,
         normaliseFileIndex: (values) => normaliseFileIndex(values),
         buildTreeFromFlatList: (list) => buildTreeFromFlatList(list),
+        getCssNumber: (variableName, fallback) => getCssNumber(rootElement, variableName, fallback),
     };
     const markdownContext = {
         content,
@@ -201,27 +216,13 @@ function bootstrap() {
     const realtimeService = createRealtimeService({
         getSubscriptionPath: () => appState.originalPathArgument,
         onConnectionChange: (connected) => {
-            setConnectionStatus(connected);
+            setConnectionStatusHandler(connected);
         },
         onDirectoryUpdate: handleDirectoryUpdate,
         onFileChanged: handleFileChanged,
     });
 
-    const viewerApi = {
-        render(contentValue, options = {}) {
-            renderMarkdown(markdownContext, contentValue, options);
-        },
-        captureHeadings(source) {
-            return captureHeadingLocations(markdownContext, source);
-        },
-        getHeadingLocation(slug) {
-            return getHeadingLocation(markdownContext, slug);
-        },
-        getMarkdownContext() {
-            return markdownContext;
-        },
-    };
-
+    const viewerApi = createViewerApi(markdownContext);
     const navigationApi = initNavigation(sharedContext, viewerApi);
     const editorApi = initEditor(sharedContext, viewerApi, navigationApi);
     if (typeof navigationApi?.bindEditorApi === 'function') {
@@ -231,202 +232,12 @@ function bootstrap() {
         sharedContext.updateActiveFileHighlight = () => navigationApi.updateActiveFileHighlight();
     }
 
+    resetViewToFallback = createResetViewToFallback({ sharedContext, viewerApi, editorApi });
+
     if (content && typeof editorApi?.handleHeadingActionClick === 'function') {
         content.addEventListener('click', (event) => {
             editorApi.handleHeadingActionClick(event);
         });
-    }
-
-    function normaliseFileIndex({ filesValue, treeValue }) {
-        let flat = [];
-        let tree = [];
-
-        if (Array.isArray(filesValue)) {
-            flat = filesValue;
-        } else if (filesValue && Array.isArray(filesValue.files)) {
-            flat = filesValue.files;
-            if (Array.isArray(filesValue.tree)) {
-                tree = filesValue.tree;
-            }
-        }
-
-        if (!tree.length && Array.isArray(treeValue)) {
-            tree = treeValue;
-        }
-
-        if (tree.length && !flat.length) {
-            flat = flattenTree(tree);
-        }
-
-        if (!tree.length && flat.length) {
-            tree = buildTreeFromFlatList(flat);
-        }
-
-        return { files: flat, tree };
-    }
-
-    function flattenTree(nodes) {
-        const result = [];
-        if (!Array.isArray(nodes)) {
-            return result;
-        }
-
-        const stack = [...nodes];
-        while (stack.length) {
-            const node = stack.shift();
-            if (!node || typeof node !== 'object') {
-                continue;
-            }
-
-            if (node.type === 'file') {
-                result.push({
-                    name: node.name,
-                    relativePath: node.relativePath,
-                    size: node.size,
-                    updated: node.updated,
-                });
-                continue;
-            }
-
-            if (node.type === 'directory' && Array.isArray(node.children)) {
-                stack.unshift(...node.children);
-            }
-        }
-
-        return result;
-    }
-
-    function buildTreeFromFlatList(flatList) {
-        if (!Array.isArray(flatList) || !flatList.length) {
-            return [];
-        }
-
-        const root = [];
-        const directoryMap = new Map();
-        directoryMap.set('', root);
-
-        function ensureDirectory(path, name) {
-            if (directoryMap.has(path)) {
-                return directoryMap.get(path);
-            }
-
-            const parentPath = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : '';
-            const parentChildren = directoryMap.get(parentPath) || root;
-            const node = {
-                type: 'directory',
-                name,
-                relativePath: path,
-                children: [],
-            };
-            parentChildren.push(node);
-            directoryMap.set(path, node.children);
-            return node.children;
-        }
-
-        flatList.forEach((file) => {
-            if (!file || typeof file.relativePath !== 'string') {
-                return;
-            }
-
-            const segments = file.relativePath.split('/');
-            const fileName = segments.pop();
-            let currentPath = '';
-            segments.forEach((segment) => {
-                if (!segment) {
-                    return;
-                }
-                currentPath = currentPath ? `${currentPath}/${segment}` : segment;
-                ensureDirectory(currentPath, segment);
-            });
-
-            const parentPath = segments.join('/');
-            const parentChildren = directoryMap.get(parentPath) || root;
-            parentChildren.push({
-                type: 'file',
-                name: fileName,
-                relativePath: file.relativePath,
-                size: file.size,
-                updated: file.updated,
-            });
-        });
-
-        sortTree(root);
-        return root;
-    }
-
-    function sortTree(nodes) {
-        if (!Array.isArray(nodes)) {
-            return;
-        }
-        nodes.sort((a, b) => {
-            if (a.type === b.type) {
-                return String(a.name || '').localeCompare(String(b.name || ''));
-            }
-            return a.type === 'directory' ? -1 : 1;
-        });
-        nodes.forEach((node) => {
-            if (node.type === 'directory') {
-                sortTree(node.children);
-            }
-        });
-    }
-
-    function getCssNumber(variableName, fallback) {
-        if (typeof variableName !== 'string' || !variableName) {
-            return typeof fallback === 'number' ? fallback : 0;
-        }
-
-        try {
-            const computed = getComputedStyle(rootElement).getPropertyValue(variableName);
-            const parsed = Number.parseFloat(computed);
-            if (Number.isFinite(parsed)) {
-                return parsed;
-            }
-        } catch (error) {
-            console.warn('Failed to read CSS variable', variableName, error);
-        }
-
-        return typeof fallback === 'number' ? fallback : 0;
-    }
-
-    function setStatus(message) {
-        // Status banner removed; keep function to avoid touching callers.
-        void message;
-    }
-
-    function setConnectionStatus(connected) {
-        offlineOverlay?.classList.toggle('visible', !connected);
-    }
-
-    function applyHasPendingChanges(value) {
-        const nextValue = Boolean(value);
-        if (nextValue === appState.hasPendingChanges) {
-            return;
-        }
-        appState.hasPendingChanges = nextValue;
-        document.body.classList.toggle('document-has-pending-changes', appState.hasPendingChanges);
-        updateHeader();
-    }
-
-    function resetViewToFallback(options = {}) {
-        const { skipHistory = false } = options || {};
-        if (typeof editorApi?.exitEditMode === 'function') {
-            editorApi.exitEditMode({ restoreContent: false });
-        }
-        sharedContext.setCurrentFile(null, { silent: true });
-        const fallback = sharedContext.fallbackMarkdownFor(
-            sharedContext.getResolvedRootPath() || sharedContext.getOriginalPathArgument() || 'the selected path'
-        );
-        viewerApi.render(fallback, { updateCurrent: true });
-        sharedContext.updateActiveFileHighlight();
-        sharedContext.updateHeader();
-        if (!skipHistory) {
-            sharedContext.updateLocation('', { replace: true });
-        }
-    }
-
-    function fallbackMarkdownFor(path) {
-        return `# No markdown files found\n\nThe directory \`${path}\` does not contain any markdown files yet.`;
     }
 
     function updateDocumentPanelTitle() {
@@ -561,364 +372,6 @@ function bootstrap() {
         if (file && file === currentPath) {
             await navigationApi.loadFile(currentPath, { replaceHistory: true });
         }
-    }
-
-    function handleTocClick(event) {
-        const link = event.target.closest('a.toc-link');
-        if (!link) {
-            return;
-        }
-
-        const hash = link.getAttribute('href');
-        if (typeof hash !== 'string' || !hash.startsWith('#')) {
-            return;
-        }
-
-        const targetId = hash.slice(1);
-        if (!targetId) {
-            return;
-        }
-
-        const targetElement = document.getElementById(targetId);
-        if (!targetElement) {
-            return;
-        }
-
-        event.preventDefault();
-
-        try {
-            targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        } catch (error) {
-            targetElement.scrollIntoView();
-        }
-
-        if (typeof history !== 'undefined' && typeof history.replaceState === 'function') {
-            const newUrl = `${window.location.pathname}${window.location.search}#${targetId}`;
-            history.replaceState(history.state, '', newUrl);
-        }
-    }
-
-    if (tocList) {
-        tocList.addEventListener('click', handleTocClick);
-    }
-
-    sharedContext.layout = layout;
-
-    const viewerApi = {
-        render(contentValue, options = {}) {
-            renderMarkdown(markdownContext, contentValue, options);
-        },
-        captureHeadings(source) {
-            return captureHeadingLocations(markdownContext, source);
-        },
-        getHeadingLocation(slug) {
-            return getHeadingLocation(markdownContext, slug);
-        },
-        getMarkdownContext() {
-            return markdownContext;
-        },
-    };
-
-    const navigationApi = initNavigation(sharedContext, viewerApi);
-    const editorApi = initEditor(sharedContext, viewerApi, navigationApi);
-    if (typeof navigationApi?.bindEditorApi === 'function') {
-        navigationApi.bindEditorApi(editorApi);
-    }
-    if (typeof navigationApi?.updateActiveFileHighlight === 'function') {
-        sharedContext.updateActiveFileHighlight = () => navigationApi.updateActiveFileHighlight();
-    }
-
-    if (content && typeof editorApi?.handleHeadingActionClick === 'function') {
-        content.addEventListener('click', (event) => {
-            editorApi.handleHeadingActionClick(event);
-        });
-    }
-
-    function normaliseFileIndex({ filesValue, treeValue }) {
-        let flat = [];
-        let tree = [];
-
-        if (Array.isArray(filesValue)) {
-            flat = filesValue;
-        } else if (filesValue && Array.isArray(filesValue.files)) {
-            flat = filesValue.files;
-            if (Array.isArray(filesValue.tree)) {
-                tree = filesValue.tree;
-            }
-        }
-
-        if (!tree.length && Array.isArray(treeValue)) {
-            tree = treeValue;
-        }
-
-        if (tree.length && !flat.length) {
-            flat = flattenTree(tree);
-        }
-
-        if (!tree.length && flat.length) {
-            tree = buildTreeFromFlatList(flat);
-        }
-
-        return { files: flat, tree };
-    }
-
-    function flattenTree(nodes) {
-        const result = [];
-        if (!Array.isArray(nodes)) {
-            return result;
-        }
-
-        const stack = [...nodes];
-        while (stack.length) {
-            const node = stack.shift();
-            if (!node || typeof node !== 'object') {
-                continue;
-            }
-
-            if (node.type === 'file') {
-                result.push({
-                    name: node.name,
-                    relativePath: node.relativePath,
-                    size: node.size,
-                    updated: node.updated,
-                });
-                continue;
-            }
-
-            if (node.type === 'directory' && Array.isArray(node.children)) {
-                stack.unshift(...node.children);
-            }
-        }
-
-        return result;
-    }
-
-    function buildTreeFromFlatList(flatList) {
-        if (!Array.isArray(flatList) || !flatList.length) {
-            return [];
-        }
-
-        const root = [];
-        const directoryMap = new Map();
-        directoryMap.set('', root);
-
-        function ensureDirectory(path, name) {
-            if (directoryMap.has(path)) {
-                return directoryMap.get(path);
-            }
-
-            const parentPath = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : '';
-            const parentChildren = directoryMap.get(parentPath) || root;
-            const node = {
-                type: 'directory',
-                name,
-                relativePath: path,
-                children: [],
-            };
-            parentChildren.push(node);
-            directoryMap.set(path, node.children);
-            return node.children;
-        }
-
-        flatList.forEach((file) => {
-            if (!file || typeof file.relativePath !== 'string') {
-                return;
-            }
-
-            const segments = file.relativePath.split('/');
-            const fileName = segments.pop();
-            let currentPath = '';
-            segments.forEach((segment) => {
-                if (!segment) {
-                    return;
-                }
-                currentPath = currentPath ? `${currentPath}/${segment}` : segment;
-                ensureDirectory(currentPath, segment);
-            });
-
-            const parentPath = segments.join('/');
-            const parentChildren = directoryMap.get(parentPath) || root;
-            parentChildren.push({
-                type: 'file',
-                name: fileName,
-                relativePath: file.relativePath,
-                size: file.size,
-                updated: file.updated,
-            });
-        });
-
-        sortTree(root);
-        return root;
-    }
-
-    function sortTree(nodes) {
-        if (!Array.isArray(nodes)) {
-            return;
-        }
-        nodes.sort((a, b) => {
-            if (a.type === b.type) {
-                return String(a.name || '').localeCompare(String(b.name || ''));
-            }
-            return a.type === 'directory' ? -1 : 1;
-        });
-        nodes.forEach((node) => {
-            if (node.type === 'directory') {
-                sortTree(node.children);
-            }
-        });
-    }
-
-    function getCssNumber(variableName, fallback) {
-        if (typeof variableName !== 'string' || !variableName) {
-            return typeof fallback === 'number' ? fallback : 0;
-        }
-
-        try {
-            const computed = getComputedStyle(rootElement).getPropertyValue(variableName);
-            const parsed = Number.parseFloat(computed);
-            if (Number.isFinite(parsed)) {
-                return parsed;
-            }
-        } catch (error) {
-            console.warn('Failed to read CSS variable', variableName, error);
-        }
-
-        return typeof fallback === 'number' ? fallback : 0;
-    }
-
-    function setStatus(message) {
-        // Status banner removed; keep function to avoid touching callers.
-        void message;
-    }
-
-    function setConnectionStatus(connected) {
-        offlineOverlay?.classList.toggle('visible', !connected);
-    }
-
-    function applyHasPendingChanges(value) {
-        const nextValue = Boolean(value);
-        if (nextValue === appState.hasPendingChanges) {
-            return;
-        }
-        appState.hasPendingChanges = nextValue;
-        document.body.classList.toggle('document-has-pending-changes', appState.hasPendingChanges);
-        updateHeader();
-    }
-
-    function resetViewToFallback(options = {}) {
-        const { skipHistory = false } = options || {};
-        if (typeof editorApi?.exitEditMode === 'function') {
-            editorApi.exitEditMode({ restoreContent: false });
-        }
-        sharedContext.setCurrentFile(null, { silent: true });
-        const fallback = sharedContext.fallbackMarkdownFor(
-            sharedContext.getResolvedRootPath() || sharedContext.getOriginalPathArgument() || 'the selected path'
-        );
-        viewerApi.render(fallback, { updateCurrent: true });
-        sharedContext.updateActiveFileHighlight();
-        sharedContext.updateHeader();
-        if (!skipHistory) {
-            sharedContext.updateLocation('', { replace: true });
-        }
-    }
-
-    function fallbackMarkdownFor(path) {
-        return `# No markdown files found\n\nThe directory \`${path}\` does not contain any markdown files yet.`;
-    }
-
-    function updateDocumentPanelTitle() {
-        const viewerPanel = dockviewSetup?.panels?.viewer;
-        if (!viewerPanel) {
-            return;
-        }
-
-        const baseTitle = appState.currentFile || 'Document';
-        const title = appState.hasPendingChanges && appState.currentFile ? `${baseTitle} ●` : baseTitle;
-        const panelApi = viewerPanel?.api;
-
-        if (panelApi && typeof panelApi.setTitle === 'function') {
-            panelApi.setTitle(title);
-        } else if (typeof viewerPanel.setTitle === 'function') {
-            viewerPanel.setTitle(title);
-        }
-    }
-
-    function updateHeader() {
-        const hasFile = Boolean(appState.currentFile);
-        const indicator = appState.hasPendingChanges && hasFile ? ' ●' : '';
-
-        if (fileName) {
-            if (dockviewIsActive) {
-                if (hasFile) {
-                    fileName.textContent = `Markdown Viewer${indicator}`;
-                    fileName.classList.add('hidden');
-                } else {
-                    fileName.textContent = 'No file selected';
-                    fileName.classList.remove('hidden');
-                }
-            } else {
-                fileName.classList.remove('hidden');
-                const baseName = hasFile ? appState.currentFile : 'No file selected';
-                fileName.textContent = hasFile ? `${baseName}${indicator}` : baseName;
-            }
-        }
-
-        sidebarPath.textContent = appState.resolvedRootPath || appState.originalPathArgument || 'Unknown';
-        downloadButton.disabled = !hasFile;
-        deleteButton.disabled = !hasFile;
-        editButton.disabled = !hasFile && !appState.isEditing;
-        previewButton.disabled = !hasFile;
-        saveButton.disabled = !hasFile;
-        cancelButton.disabled = false;
-        updateActionVisibility();
-        updateDocumentPanelTitle();
-    }
-
-    function updateActionVisibility() {
-        const hasFile = Boolean(appState.currentFile);
-        editButton.classList.toggle('hidden', !hasFile || (appState.isEditing && !appState.isPreviewing));
-        previewButton.classList.toggle('hidden', !appState.isEditing || appState.isPreviewing);
-        saveButton.classList.toggle('hidden', !appState.isEditing);
-        cancelButton.classList.toggle('hidden', !appState.isEditing);
-        downloadButton.classList.toggle('hidden', appState.isEditing);
-        deleteButton.classList.toggle('hidden', appState.isEditing);
-    }
-
-    function buildQuery(params) {
-        const query = new URLSearchParams();
-        if (appState.originalPathArgument) {
-            query.set('path', appState.originalPathArgument);
-        }
-        Object.entries(params).forEach(([key, value]) => {
-            if (value !== undefined && value !== null && value !== '') {
-                query.set(key, value);
-            }
-        });
-        const queryString = query.toString();
-        return queryString ? `?${queryString}` : '';
-    }
-
-    function updateLocation(file, { replace = false } = {}) {
-        const newQuery = buildQuery({ file });
-        const newUrl = `${window.location.pathname}${newQuery}`;
-        const currentUrl = `${window.location.pathname}${window.location.search}`;
-        const stateData = { file };
-
-        if (replace || newUrl === currentUrl) {
-            window.history.replaceState(stateData, '', newUrl);
-        } else {
-            window.history.pushState(stateData, '', newUrl);
-        }
-    }
-
-    function fileFromSearch(search) {
-        const params = new URLSearchParams(search || '');
-        const value = params.get('file');
-        if (typeof value !== 'string') {
-            return '';
-        }
-        const trimmed = value.trim();
-        return trimmed === '' ? '' : trimmed;
     }
 
     function handleTocClick(event) {


### PR DESCRIPTION
## Summary
- move viewer bootstrap helpers into `app/bootstrap_helpers.js` so they can be reused across modules
- update the unified bootstrap to consume the shared helpers and remove the duplicate inline definitions
- adjust the navigation module to import the shared helpers directly when rebuilding file trees and fallbacks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e244a4286c8328aa351d3979ffd3d2