### PR TITLE
Refactor unified bootstrap into controllers with tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,11 +2,13 @@
   "name": "asynkron-liveview-frontend",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "npm run clean && npm run build:js && npm run build:css",
     "build:js": "esbuild src/js/unified_index.js src/js/print_view.js --bundle --minify --sourcemap --target=es2018 --outdir=../templates/static/dist --inject:src/js/process_shim.js '--define:process.env.NODE_ENV=\"production\"'",
     "build:css": "esbuild src/css/app.css src/css/print.css --bundle --minify --outdir=../templates/static/dist --loader:.woff2=file --loader:.woff=file --loader:.ttf=file",
-    "clean": "rimraf ../templates/static/dist"
+    "clean": "rimraf ../templates/static/dist",
+    "test": "node --test"
   },
   "devDependencies": {
     "esbuild": "^0.25.10",

--- a/frontend/src/js/app/bootstrap_helpers.js
+++ b/frontend/src/js/app/bootstrap_helpers.js
@@ -180,18 +180,6 @@ export function createSetConnectionStatus(offlineOverlay) {
     };
 }
 
-export function createApplyHasPendingChanges(appState, updateHeader) {
-    return function applyHasPendingChanges(value) {
-        const nextValue = Boolean(value);
-        if (nextValue === appState.hasPendingChanges) {
-            return;
-        }
-        appState.hasPendingChanges = nextValue;
-        document.body.classList.toggle('document-has-pending-changes', appState.hasPendingChanges);
-        updateHeader();
-    };
-}
-
 export function createResetViewToFallback({ sharedContext, viewerApi, editorApi }) {
     return function resetViewToFallback(options = {}) {
         const { skipHistory = false } = options || {};

--- a/frontend/src/js/app/header_controller.js
+++ b/frontend/src/js/app/header_controller.js
@@ -1,0 +1,122 @@
+const INDICATOR = ' ●';
+
+/**
+ * Creates an imperative controller for managing the application header.
+ */
+export function createHeaderController({ elements = {}, layout = {}, appState }) {
+    if (!appState) {
+        throw new Error('appState is required to create the header controller.');
+    }
+
+    const {
+        fileName,
+        sidebarPath,
+        downloadButton,
+        deleteButton,
+        editButton,
+        previewButton,
+        saveButton,
+        cancelButton,
+    } = elements;
+
+    function getDockviewSetup() {
+        return layout?.dockviewSetup ?? null;
+    }
+
+    function isDockviewActive() {
+        const activeFlag = layout?.dockviewIsActive;
+        return typeof activeFlag === 'boolean' ? activeFlag : Boolean(activeFlag);
+    }
+
+    function updateDocumentPanelTitle() {
+        const viewerPanel = getDockviewSetup()?.panels?.viewer;
+        if (!viewerPanel) {
+            return;
+        }
+
+        const baseTitle = appState.currentFile || 'Document';
+        const indicator = appState.hasPendingChanges && appState.currentFile ? INDICATOR : '';
+        const title = `${baseTitle}${indicator}`;
+        const panelApi = viewerPanel?.api;
+
+        if (panelApi && typeof panelApi.setTitle === 'function') {
+            panelApi.setTitle(title);
+        } else if (typeof viewerPanel.setTitle === 'function') {
+            viewerPanel.setTitle(title);
+        }
+    }
+
+    function updateActionVisibility() {
+        const hasFile = Boolean(appState.currentFile);
+        const editing = Boolean(appState.isEditing);
+        const previewing = Boolean(appState.isPreviewing);
+
+        editButton?.classList?.toggle('hidden', !hasFile || (editing && !previewing));
+        previewButton?.classList?.toggle('hidden', !editing || previewing);
+        saveButton?.classList?.toggle('hidden', !editing);
+        cancelButton?.classList?.toggle('hidden', !editing);
+        downloadButton?.classList?.toggle('hidden', editing);
+        deleteButton?.classList?.toggle('hidden', editing);
+    }
+
+    function updateHeader() {
+        const hasFile = Boolean(appState.currentFile);
+        const indicator = appState.hasPendingChanges && hasFile ? INDICATOR : '';
+
+        if (fileName) {
+            if (isDockviewActive()) {
+                if (hasFile) {
+                    fileName.textContent = `Markdown Viewer${indicator}`;
+                    fileName.classList.add('hidden');
+                } else {
+                    fileName.textContent = 'No file selected';
+                    fileName.classList.remove('hidden');
+                }
+            } else {
+                fileName.classList.remove('hidden');
+                const baseName = hasFile ? appState.currentFile : 'No file selected';
+                fileName.textContent = hasFile ? `${baseName}${indicator}` : baseName;
+            }
+        }
+
+        if (sidebarPath) {
+            sidebarPath.textContent = appState.resolvedRootPath
+                || appState.originalPathArgument
+                || 'Unknown';
+        }
+
+        const toggleDisable = (button, disabled) => {
+            if (button) {
+                button.disabled = Boolean(disabled);
+            }
+        };
+
+        toggleDisable(downloadButton, !hasFile);
+        toggleDisable(deleteButton, !hasFile);
+        toggleDisable(editButton, !hasFile && !appState.isEditing);
+        toggleDisable(previewButton, !hasFile);
+        toggleDisable(saveButton, !hasFile);
+        toggleDisable(cancelButton, false);
+
+        updateActionVisibility();
+        updateDocumentPanelTitle();
+    }
+
+    function applyHasPendingChanges(value) {
+        const nextValue = Boolean(value);
+        if (nextValue === appState.hasPendingChanges) {
+            return;
+        }
+
+        appState.hasPendingChanges = nextValue;
+        document?.body?.classList?.toggle('document-has-pending-changes', nextValue);
+        updateHeader();
+    }
+
+    return {
+        updateHeader,
+        updateActionVisibility,
+        updateDocumentPanelTitle,
+        applyHasPendingChanges,
+    };
+}

--- a/frontend/src/js/app/router.js
+++ b/frontend/src/js/app/router.js
@@ -1,0 +1,91 @@
+function normaliseSearch(search) {
+    return typeof search === 'string' ? search : '';
+}
+
+function fileFromSearch(search) {
+    const params = new URLSearchParams(normaliseSearch(search));
+    const value = params.get('file');
+    if (typeof value !== 'string') {
+        return '';
+    }
+    const trimmed = value.trim();
+    return trimmed === '' ? '' : trimmed;
+}
+
+export function createRouter({
+    appState,
+    getCurrentFile = () => null,
+    onNavigate = () => {},
+    onFallback = () => {},
+    windowRef = window,
+} = {}) {
+    if (!appState) {
+        throw new Error('appState is required to create the router.');
+    }
+
+    const historyRef = windowRef?.history;
+
+    function buildQuery(params = {}) {
+        const query = new URLSearchParams();
+        if (appState.originalPathArgument) {
+            query.set('path', appState.originalPathArgument);
+        }
+        Object.entries(params).forEach(([key, value]) => {
+            if (value !== undefined && value !== null && value !== '') {
+                query.set(key, value);
+            }
+        });
+        const queryString = query.toString();
+        return queryString ? `?${queryString}` : '';
+    }
+
+    function updateLocation(file, { replace = false } = {}) {
+        if (!windowRef || !historyRef) {
+            return;
+        }
+        const search = buildQuery({ file });
+        const newUrl = `${windowRef.location?.pathname ?? ''}${search}`;
+        const currentUrl = `${windowRef.location?.pathname ?? ''}${normaliseSearch(windowRef.location?.search)}`;
+        const stateData = { file };
+
+        if (replace || newUrl === currentUrl) {
+            historyRef.replaceState?.(stateData, '', newUrl);
+        } else {
+            historyRef.pushState?.(stateData, '', newUrl);
+        }
+    }
+
+    function getCurrent() {
+        return fileFromSearch(windowRef?.location?.search);
+    }
+
+    function handlePopState() {
+        const targetFile = getCurrent();
+        const currentFile = getCurrentFile();
+        if (targetFile) {
+            if (targetFile !== currentFile) {
+                onNavigate(targetFile, { skipHistory: true, replaceHistory: true });
+            }
+        } else {
+            onFallback({ skipHistory: true });
+        }
+    }
+
+    windowRef?.addEventListener?.('popstate', handlePopState);
+
+    return {
+        buildQuery,
+        push(file) {
+            updateLocation(file, { replace: false });
+        },
+        replace(file) {
+            updateLocation(file, { replace: true });
+        },
+        getCurrent,
+        dispose() {
+            windowRef?.removeEventListener?.('popstate', handlePopState);
+        },
+    };
+}
+
+export const __test__ = { fileFromSearch };

--- a/frontend/src/js/app/toc_controller.js
+++ b/frontend/src/js/app/toc_controller.js
@@ -1,0 +1,59 @@
+/**
+ * Provides helpers for wiring up the table-of-contents sidebar.
+ */
+export function createTocController({ tocList, documentRef = document, windowRef = window } = {}) {
+    function handleTocClick(event) {
+        const link = event.target?.closest?.('a.toc-link');
+        if (!link) {
+            return;
+        }
+
+        const hash = link.getAttribute('href');
+        if (typeof hash !== 'string' || !hash.startsWith('#')) {
+            return;
+        }
+
+        const targetId = hash.slice(1);
+        if (!targetId) {
+            return;
+        }
+
+        const targetElement = documentRef.getElementById?.(targetId);
+        if (!targetElement) {
+            return;
+        }
+
+        event.preventDefault?.();
+
+        try {
+            targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        } catch (error) {
+            void error;
+            targetElement.scrollIntoView?.();
+        }
+
+        const historyRef = windowRef?.history;
+        if (historyRef && typeof historyRef.replaceState === 'function') {
+            const pathname = windowRef?.location?.pathname ?? '';
+            const search = windowRef?.location?.search ?? '';
+            const newUrl = `${pathname}${search}#${targetId}`;
+            historyRef.replaceState(historyRef.state, '', newUrl);
+        }
+    }
+
+    function attach(target = tocList) {
+        if (!target?.addEventListener) {
+            return () => {};
+        }
+
+        target.addEventListener('click', handleTocClick);
+        return () => {
+            target.removeEventListener?.('click', handleTocClick);
+        };
+    }
+
+    return {
+        attach,
+        handleTocClick,
+    };
+}

--- a/frontend/src/js/unified_index.js
+++ b/frontend/src/js/unified_index.js
@@ -13,10 +13,12 @@ import {
     getCssNumber,
     setStatus,
     createSetConnectionStatus,
-    createApplyHasPendingChanges,
     createResetViewToFallback,
     fallbackMarkdownFor,
 } from './app/bootstrap_helpers.js';
+import { createHeaderController } from './app/header_controller.js';
+import { createRouter } from './app/router.js';
+import { createTocController } from './app/toc_controller.js';
 
 // Client-side bootstrap logic for the unified markdown viewer UI.
 function bootstrap() {
@@ -68,11 +70,15 @@ function bootstrap() {
     appState.fileTree = initialIndex.tree;
 
     appState.currentFile = initialState.selectedFile || null;
-    context.initialFileFromLocation = fileFromSearch(window.location.search);
+    context.initialFileFromLocation = null;
 
     const setConnectionStatusHandler = createSetConnectionStatus(offlineOverlay);
-    const applyHasPendingChanges = createApplyHasPendingChanges(appState, updateHeader);
     let resetViewToFallback = () => {};
+    let headerController = null;
+    let router = null;
+    let navigationApi = null;
+    let editorApi = null;
+    let tocController = null;
 
     const sharedContext = {
         elements: {
@@ -114,7 +120,17 @@ function bootstrap() {
             appState.currentContent = typeof value === 'string' ? value : '';
         },
         hasPendingChanges: () => appState.hasPendingChanges,
-        setHasPendingChanges: (value) => applyHasPendingChanges(value),
+        setHasPendingChanges(value) {
+            if (headerController) {
+                headerController.applyHasPendingChanges(value);
+            } else {
+                const nextValue = Boolean(value);
+                if (nextValue !== appState.hasPendingChanges) {
+                    appState.hasPendingChanges = nextValue;
+                    document?.body?.classList?.toggle('document-has-pending-changes', nextValue);
+                }
+            }
+        },
         isEditing: () => appState.isEditing,
         setEditing(value) {
             const next = Boolean(value);
@@ -151,17 +167,29 @@ function bootstrap() {
         setStatus,
         setConnectionStatus: (connected) => setConnectionStatusHandler(connected),
         updateHeader() {
-            updateHeader();
+            headerController?.updateHeader();
         },
         updateActionVisibility() {
-            updateActionVisibility();
+            headerController?.updateActionVisibility();
         },
         updateActiveFileHighlight() {},
         updateDocumentPanelTitle() {
-            updateDocumentPanelTitle();
+            headerController?.updateDocumentPanelTitle();
         },
-        buildQuery: (params) => buildQuery(params),
-        updateLocation: (file, options) => updateLocation(file, options),
+        buildQuery(params) {
+            return router ? router.buildQuery(params) : '';
+        },
+        updateLocation(file, options = {}) {
+            if (!router) {
+                return;
+            }
+            const { replace = false } = options;
+            if (replace) {
+                router.replace(file);
+            } else {
+                router.push(file);
+            }
+        },
         fallbackMarkdownFor,
         normaliseFileIndex: (values) => normaliseFileIndex(values),
         buildTreeFromFlatList: (list) => buildTreeFromFlatList(list),
@@ -174,7 +202,7 @@ function bootstrap() {
         setCurrentContent(value) {
             sharedContext.setCurrentContent(value);
         },
-        buildQuery,
+        buildQuery: (params) => sharedContext.buildQuery(params),
     };
     sharedContext.markdownContext = markdownContext;
 
@@ -191,10 +219,27 @@ function bootstrap() {
         panelToggleButtons,
         getCurrentFile: () => sharedContext.getCurrentFile(),
     });
-    const dockviewSetup = layout.dockviewSetup;
     const dockviewIsActive = layout.dockviewIsActive;
     document.body.classList.toggle('dockview-active', dockviewIsActive);
     layout.refreshPanelToggleStates();
+
+    headerController = createHeaderController({
+        elements: {
+            fileName,
+            sidebarPath,
+            downloadButton,
+            deleteButton,
+            editButton,
+            previewButton,
+            saveButton,
+            cancelButton,
+        },
+        layout,
+        appState,
+    });
+
+    tocController = createTocController({ tocList });
+    tocController.attach();
 
     if (dockviewIsActive && dockviewRoot) {
         dockviewRoot.addEventListener('pointerdown', layout.handlePointerDown);
@@ -203,6 +248,21 @@ function bootstrap() {
     }
 
     sharedContext.layout = layout;
+
+    router = createRouter({
+        appState,
+        getCurrentFile: () => sharedContext.getCurrentFile(),
+        onNavigate: (targetFile, options) => {
+            if (typeof navigationApi?.loadFile === 'function') {
+                void navigationApi.loadFile(targetFile, options);
+            }
+        },
+        onFallback: (options) => {
+            resetViewToFallback(options);
+        },
+    });
+
+    context.initialFileFromLocation = router.getCurrent();
 
     const terminalService = createTerminalService({
         terminalPanel,
@@ -216,8 +276,8 @@ function bootstrap() {
 
     const viewerApi = createViewerApi(markdownContext);
 
-    const navigationApi = initNavigation(sharedContext, viewerApi);
-    const editorApi = initEditor(sharedContext, viewerApi, navigationApi);
+    navigationApi = initNavigation(sharedContext, viewerApi);
+    editorApi = initEditor(sharedContext, viewerApi, navigationApi);
     if (typeof navigationApi?.bindEditorApi === 'function') {
         navigationApi.bindEditorApi(editorApi);
     }
@@ -252,147 +312,13 @@ function bootstrap() {
         onFileChanged: handleFileChanged,
     });
 
-    function updateDocumentPanelTitle() {
-        const viewerPanel = dockviewSetup?.panels?.viewer;
-        if (!viewerPanel) {
-            return;
-        }
-
-        const baseTitle = appState.currentFile || 'Document';
-        const title = appState.hasPendingChanges && appState.currentFile ? `${baseTitle} ●` : baseTitle;
-        const panelApi = viewerPanel?.api;
-
-        if (panelApi && typeof panelApi.setTitle === 'function') {
-            panelApi.setTitle(title);
-        } else if (typeof viewerPanel.setTitle === 'function') {
-            viewerPanel.setTitle(title);
-        }
-    }
-
-    function updateHeader() {
-        const hasFile = Boolean(appState.currentFile);
-        const indicator = appState.hasPendingChanges && hasFile ? ' ●' : '';
-
-        if (fileName) {
-            if (dockviewIsActive) {
-                if (hasFile) {
-                    fileName.textContent = `Markdown Viewer${indicator}`;
-                    fileName.classList.add('hidden');
-                } else {
-                    fileName.textContent = 'No file selected';
-                    fileName.classList.remove('hidden');
-                }
-            } else {
-                fileName.classList.remove('hidden');
-                const baseName = hasFile ? appState.currentFile : 'No file selected';
-                fileName.textContent = hasFile ? `${baseName}${indicator}` : baseName;
-            }
-        }
-
-        sidebarPath.textContent = appState.resolvedRootPath || appState.originalPathArgument || 'Unknown';
-        downloadButton.disabled = !hasFile;
-        deleteButton.disabled = !hasFile;
-        editButton.disabled = !hasFile && !appState.isEditing;
-        previewButton.disabled = !hasFile;
-        saveButton.disabled = !hasFile;
-        cancelButton.disabled = false;
-        updateActionVisibility();
-        updateDocumentPanelTitle();
-    }
-
-    function updateActionVisibility() {
-        const hasFile = Boolean(appState.currentFile);
-        editButton.classList.toggle('hidden', !hasFile || (appState.isEditing && !appState.isPreviewing));
-        previewButton.classList.toggle('hidden', !appState.isEditing || appState.isPreviewing);
-        saveButton.classList.toggle('hidden', !appState.isEditing);
-        cancelButton.classList.toggle('hidden', !appState.isEditing);
-        downloadButton.classList.toggle('hidden', appState.isEditing);
-        deleteButton.classList.toggle('hidden', appState.isEditing);
-    }
-
-    function buildQuery(params) {
-        const query = new URLSearchParams();
-        if (appState.originalPathArgument) {
-            query.set('path', appState.originalPathArgument);
-        }
-        Object.entries(params).forEach(([key, value]) => {
-            if (value !== undefined && value !== null && value !== '') {
-                query.set(key, value);
-            }
-        });
-        const queryString = query.toString();
-        return queryString ? `?${queryString}` : '';
-    }
-
-    function updateLocation(file, { replace = false } = {}) {
-        const newQuery = buildQuery({ file });
-        const newUrl = `${window.location.pathname}${newQuery}`;
-        const currentUrl = `${window.location.pathname}${window.location.search}`;
-        const stateData = { file };
-
-        if (replace || newUrl === currentUrl) {
-            window.history.replaceState(stateData, '', newUrl);
-        } else {
-            window.history.pushState(stateData, '', newUrl);
-        }
-    }
-
-    function fileFromSearch(search) {
-        const params = new URLSearchParams(search || '');
-        const value = params.get('file');
-        if (typeof value !== 'string') {
-            return '';
-        }
-        const trimmed = value.trim();
-        return trimmed === '' ? '' : trimmed;
-    }
-
-    function handleTocClick(event) {
-        const link = event.target.closest('a.toc-link');
-        if (!link) {
-            return;
-        }
-
-        const hash = link.getAttribute('href');
-        if (typeof hash !== 'string' || !hash.startsWith('#')) {
-            return;
-        }
-
-        const targetId = hash.slice(1);
-        if (!targetId) {
-            return;
-        }
-
-        const targetElement = document.getElementById(targetId);
-        if (!targetElement) {
-            return;
-        }
-
-        event.preventDefault();
-
-        try {
-            targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        } catch (error) {
-            targetElement.scrollIntoView();
-        }
-
-        if (typeof history !== 'undefined' && typeof history.replaceState === 'function') {
-            const newUrl = `${window.location.pathname}${window.location.search}#${targetId}`;
-            history.replaceState(history.state, '', newUrl);
-        }
-    }
-
-    if (tocList) {
-        tocList.addEventListener('click', handleTocClick);
-    }
-
     function initialise() {
         const initialFallback = fallbackMarkdownFor(
             appState.resolvedRootPath || appState.originalPathArgument || 'the selected path'
         );
         viewerApi.render(initialState.content || initialFallback, { updateCurrent: true });
         navigationApi.renderFileList();
-        updateHeader();
+        sharedContext.updateHeader();
         if (initialState.error) {
             setStatus(initialState.error);
         }
@@ -408,18 +334,6 @@ function bootstrap() {
             void navigationApi.loadFile(currentPath, { replaceHistory: true });
         }
     }
-
-    window.addEventListener('popstate', () => {
-        const targetFile = fileFromSearch(window.location.search);
-        const currentPath = sharedContext.getCurrentFile();
-        if (targetFile) {
-            if (targetFile !== currentPath) {
-                void navigationApi.loadFile(targetFile, { skipHistory: true, replaceHistory: true });
-            }
-        } else {
-            resetViewToFallback({ skipHistory: true });
-        }
-    });
 
     initialise();
 

--- a/frontend/tests/app/header_controller.test.js
+++ b/frontend/tests/app/header_controller.test.js
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import { beforeEach, test } from 'node:test';
+import { createHeaderController } from '../../src/js/app/header_controller.js';
+
+function createClassList() {
+    const values = new Set();
+    return {
+        add(value) {
+            values.add(value);
+        },
+        remove(value) {
+            values.delete(value);
+        },
+        toggle(value, force) {
+            if (force === undefined) {
+                if (values.has(value)) {
+                    values.delete(value);
+                    return false;
+                }
+                values.add(value);
+                return true;
+            }
+            if (force) {
+                values.add(value);
+                return true;
+            }
+            values.delete(value);
+            return false;
+        },
+        contains(value) {
+            return values.has(value);
+        },
+    };
+}
+
+function createElement() {
+    return {
+        textContent: '',
+        classList: createClassList(),
+        disabled: false,
+    };
+}
+
+let appState;
+let elements;
+let layout;
+let viewerTitle;
+
+beforeEach(() => {
+    viewerTitle = 'Document';
+    appState = {
+        currentFile: 'README.md',
+        hasPendingChanges: false,
+        isEditing: false,
+        isPreviewing: false,
+        resolvedRootPath: '/docs',
+        originalPathArgument: '/docs',
+    };
+
+    elements = {
+        fileName: createElement(),
+        sidebarPath: createElement(),
+        downloadButton: createElement(),
+        deleteButton: createElement(),
+        editButton: createElement(),
+        previewButton: createElement(),
+        saveButton: createElement(),
+        cancelButton: createElement(),
+    };
+
+    const viewerPanel = {
+        api: {
+            setTitle(value) {
+                viewerTitle = value;
+            },
+        },
+    };
+
+    layout = {
+        dockviewSetup: { panels: { viewer: viewerPanel } },
+        dockviewIsActive: false,
+    };
+
+    global.document = {
+        body: {
+            classList: createClassList(),
+        },
+    };
+});
+
+function createController() {
+    return createHeaderController({ elements, layout, appState });
+}
+
+test('updateHeader populates file metadata', () => {
+    const controller = createController();
+    controller.updateHeader();
+
+    assert.equal(elements.fileName.textContent, 'README.md');
+    assert.equal(elements.sidebarPath.textContent, '/docs');
+    assert.equal(elements.fileName.classList.contains('hidden'), false);
+});
+
+test('applyHasPendingChanges toggles indicator text and panel title', () => {
+    const controller = createController();
+    controller.updateHeader();
+
+    controller.applyHasPendingChanges(true);
+
+    assert.equal(appState.hasPendingChanges, true);
+    assert.equal(global.document.body.classList.contains('document-has-pending-changes'), true);
+    assert.equal(elements.fileName.textContent, 'README.md ●');
+    assert.equal(viewerTitle, 'README.md ●');
+});
+
+test('updateActionVisibility reacts to editing state', () => {
+    const controller = createController();
+    appState.isEditing = true;
+    controller.updateActionVisibility();
+
+    assert.equal(elements.editButton.classList.contains('hidden'), true);
+    assert.equal(elements.previewButton.classList.contains('hidden'), false);
+    assert.equal(elements.downloadButton.classList.contains('hidden'), true);
+    assert.equal(elements.deleteButton.classList.contains('hidden'), true);
+    assert.equal(elements.saveButton.classList.contains('hidden'), false);
+    assert.equal(elements.cancelButton.classList.contains('hidden'), false);
+});
+
+test('dockview layout hides filename when active', () => {
+    layout.dockviewIsActive = true;
+    const controller = createController();
+    controller.updateHeader();
+
+    assert.equal(elements.fileName.classList.contains('hidden'), true);
+    assert.equal(elements.fileName.textContent, 'Markdown Viewer');
+});

--- a/frontend/tests/app/router.test.js
+++ b/frontend/tests/app/router.test.js
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { beforeEach, test } from 'node:test';
+import { createRouter, __test__ } from '../../src/js/app/router.js';
+
+function createWindowStub() {
+    const listeners = new Map();
+    const historyCalls = {
+        push: [],
+        replace: [],
+    };
+
+    const windowRef = {
+        location: {
+            pathname: '/viewer',
+            search: '',
+        },
+        history: {
+            pushState(state, _title, url) {
+                historyCalls.push.push({ state, url });
+                windowRef.location.search = url.includes('?') ? url.slice(url.indexOf('?')) : '';
+            },
+            replaceState(state, _title, url) {
+                historyCalls.replace.push({ state, url });
+                windowRef.location.search = url.includes('?') ? url.slice(url.indexOf('?')) : '';
+            },
+        },
+        addEventListener(name, handler) {
+            listeners.set(name, handler);
+        },
+        removeEventListener(name) {
+            listeners.delete(name);
+        },
+        getListener(name) {
+            return listeners.get(name);
+        },
+        historyCalls,
+    };
+
+    return windowRef;
+}
+
+let appState;
+let windowRef;
+let lastNavigate;
+let lastFallback;
+
+beforeEach(() => {
+    appState = { originalPathArgument: '/docs' };
+    windowRef = createWindowStub();
+    lastNavigate = null;
+    lastFallback = null;
+});
+
+test('buildQuery preserves original path argument', () => {
+    const router = createRouter({
+        appState,
+        windowRef,
+        getCurrentFile: () => null,
+        onNavigate: () => {},
+        onFallback: () => {},
+    });
+
+    assert.equal(router.buildQuery({}), '?path=%2Fdocs');
+    assert.equal(router.buildQuery({ file: 'README.md' }), '?path=%2Fdocs&file=README.md');
+    router.dispose();
+});
+
+test('push and replace update history with state payload', () => {
+    const router = createRouter({
+        appState,
+        windowRef,
+        getCurrentFile: () => null,
+    });
+
+    router.push('README.md');
+    assert.equal(windowRef.historyCalls.push.length, 1);
+    assert.deepEqual(windowRef.historyCalls.push[0], {
+        state: { file: 'README.md' },
+        url: '/viewer?path=%2Fdocs&file=README.md',
+    });
+
+    router.replace('NOTES.md');
+    assert.equal(windowRef.historyCalls.replace.length, 1);
+    assert.deepEqual(windowRef.historyCalls.replace[0], {
+        state: { file: 'NOTES.md' },
+        url: '/viewer?path=%2Fdocs&file=NOTES.md',
+    });
+
+    router.dispose();
+});
+
+test('getCurrent reads from search string', () => {
+    windowRef.location.search = '?file= notes.md ';
+    const router = createRouter({ appState, windowRef });
+    assert.equal(router.getCurrent(), 'notes.md');
+    assert.equal(__test__.fileFromSearch('?file='), '');
+    router.dispose();
+});
+
+test('popstate triggers navigation callbacks', () => {
+    const router = createRouter({
+        appState,
+        windowRef,
+        getCurrentFile: () => 'README.md',
+        onNavigate: (file, options) => {
+            lastNavigate = { file, options };
+        },
+        onFallback: (options) => {
+            lastFallback = options;
+        },
+    });
+
+    windowRef.location.search = '?file=notes.md';
+    windowRef.getListener('popstate')();
+    assert.deepEqual(lastNavigate, {
+        file: 'notes.md',
+        options: { skipHistory: true, replaceHistory: true },
+    });
+
+    windowRef.location.search = '';
+    windowRef.getListener('popstate')();
+    assert.deepEqual(lastFallback, { skipHistory: true });
+
+    router.dispose();
+});

--- a/frontend/tests/app/toc_controller.test.js
+++ b/frontend/tests/app/toc_controller.test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createTocController } from '../../src/js/app/toc_controller.js';
+
+function createEventTarget() {
+    let handler = null;
+    return {
+        addEventListener(name, callback) {
+            if (name === 'click') {
+                handler = callback;
+            }
+        },
+        removeEventListener(name, callback) {
+            if (name === 'click' && handler === callback) {
+                handler = null;
+            }
+        },
+        dispatch(event) {
+            handler?.(event);
+        },
+        get handler() {
+            return handler;
+        },
+    };
+}
+
+test('attach wires click handler that scrolls and updates history', () => {
+    const tocList = createEventTarget();
+    let prevented = false;
+    let scrolledWith;
+    let historyUrl;
+
+    const targetElement = {
+        scrollIntoView(options) {
+            scrolledWith = options;
+        },
+    };
+
+    const documentRef = {
+        getElementById(id) {
+            return id === 'heading-one' ? targetElement : null;
+        },
+    };
+
+    const historyState = [];
+    const windowRef = {
+        location: { pathname: '/viewer', search: '?file=README.md' },
+        history: {
+            state: { test: true },
+            replaceState(state, _title, url) {
+                historyState.push({ state, url });
+                historyUrl = url;
+            },
+        },
+    };
+
+    const controller = createTocController({ tocList, documentRef, windowRef });
+    const detach = controller.attach();
+
+    const anchor = {
+        closest(selector) {
+            return selector === 'a.toc-link' ? this : null;
+        },
+        getAttribute(name) {
+            if (name === 'href') {
+                return '#heading-one';
+            }
+            return null;
+        },
+    };
+
+    const event = {
+        target: anchor,
+        preventDefault() {
+            prevented = true;
+        },
+    };
+
+    tocList.dispatch(event);
+
+    assert.equal(prevented, true);
+    assert.deepEqual(scrolledWith, { behavior: 'smooth', block: 'start' });
+    assert.deepEqual(historyState[0], { state: windowRef.history.state, url: '/viewer?file=README.md#heading-one' });
+    assert.equal(historyUrl, '/viewer?file=README.md#heading-one');
+
+    detach();
+    assert.equal(tocList.handler, null);
+});
+


### PR DESCRIPTION
## Summary
- extract header, router, and table-of-contents controllers so unified bootstrap delegates to focused modules
- wire the new controllers into sharedContext, removing inline DOM/history logic and simplifying state updates
- enable Node's built-in test runner and add thin unit tests to cover the new controllers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2911c6c8483288b95dee18cd16b97