### PR TITLE
Refactor shared context factory

### DIFF
--- a/frontend/src/js/app/shared_context.js
+++ b/frontend/src/js/app/shared_context.js
@@ -1,0 +1,170 @@
+// Factory for the shared application context used across the unified viewer modules.
+export function createSharedContext({
+    appState,
+    elements,
+    sets,
+    applyHasPendingChanges,
+    setConnectionStatusHandler,
+    updateHeader,
+    updateActionVisibility,
+    updateDocumentPanelTitle,
+    buildQuery,
+    updateLocation,
+    fallbackMarkdownFor,
+    normaliseFileIndex,
+    buildTreeFromFlatList,
+    getCssNumber,
+    rootElement,
+}) {
+    const safeUpdateHeader = typeof updateHeader === 'function' ? updateHeader : () => {};
+    const safeUpdateActionVisibility =
+        typeof updateActionVisibility === 'function' ? updateActionVisibility : () => {};
+    const safeUpdateDocumentPanelTitle =
+        typeof updateDocumentPanelTitle === 'function' ? updateDocumentPanelTitle : () => {};
+    const safeApplyHasPendingChanges =
+        typeof applyHasPendingChanges === 'function'
+            ? applyHasPendingChanges
+            : (value) => {
+                  const nextValue = Boolean(value);
+                  if (nextValue !== appState.hasPendingChanges) {
+                      appState.hasPendingChanges = nextValue;
+                      globalThis?.document?.body?.classList?.toggle(
+                          'document-has-pending-changes',
+                          nextValue
+                      );
+                  }
+              };
+    const safeSetConnectionStatusHandler =
+        typeof setConnectionStatusHandler === 'function' ? setConnectionStatusHandler : () => {};
+    const safeBuildQuery = typeof buildQuery === 'function' ? buildQuery : () => '';
+    const safeUpdateLocation =
+        typeof updateLocation === 'function' ? updateLocation : () => {};
+    const safeFallbackMarkdownFor =
+        typeof fallbackMarkdownFor === 'function' ? fallbackMarkdownFor : () => '';
+    const safeNormaliseFileIndex =
+        typeof normaliseFileIndex === 'function' ? normaliseFileIndex : (values) => values;
+    const safeBuildTreeFromFlatList =
+        typeof buildTreeFromFlatList === 'function' ? buildTreeFromFlatList : (list) => list;
+    const safeGetCssNumber =
+        typeof getCssNumber === 'function' ? getCssNumber : (_, __, fallback) => fallback;
+    const sharedSets = sets || {};
+    const expandedDirectories = sharedSets.expandedDirectories;
+    const knownDirectories = sharedSets.knownDirectories;
+
+    const sharedContext = {
+        elements: elements || {},
+        getCurrentFile() {
+            return appState.currentFile;
+        },
+        setCurrentFile(value, options = {}) {
+            const { silent = false } = options || {};
+            const nextValue = typeof value === 'string' && value.length ? value : value || null;
+            if (appState.currentFile === nextValue) {
+                return;
+            }
+            appState.currentFile = nextValue;
+            if (!silent) {
+                sharedContext.updateActiveFileHighlight();
+                sharedContext.updateHeader();
+                sharedContext.updateDocumentPanelTitle();
+            }
+        },
+        getCurrentContent() {
+            return appState.currentContent;
+        },
+        setCurrentContent(value) {
+            appState.currentContent = typeof value === 'string' ? value : '';
+        },
+        hasPendingChanges() {
+            return appState.hasPendingChanges;
+        },
+        setHasPendingChanges(value) {
+            safeApplyHasPendingChanges(value);
+        },
+        isEditing() {
+            return appState.isEditing;
+        },
+        setEditing(value) {
+            const next = Boolean(value);
+            if (appState.isEditing === next) {
+                return;
+            }
+            appState.isEditing = next;
+            sharedContext.updateActionVisibility();
+        },
+        isPreviewing() {
+            return appState.isPreviewing;
+        },
+        setPreviewing(value) {
+            const next = Boolean(value);
+            if (appState.isPreviewing === next) {
+                return;
+            }
+            appState.isPreviewing = next;
+            sharedContext.updateActionVisibility();
+        },
+        getResolvedRootPath() {
+            return appState.resolvedRootPath;
+        },
+        setResolvedRootPath(value) {
+            if (typeof value === 'string') {
+                appState.resolvedRootPath = value;
+            }
+        },
+        getOriginalPathArgument() {
+            return appState.originalPathArgument;
+        },
+        getFiles() {
+            return appState.files;
+        },
+        setFiles(value) {
+            appState.files = Array.isArray(value) ? value : [];
+        },
+        getFileTree() {
+            return appState.fileTree;
+        },
+        setFileTree(value) {
+            appState.fileTree = Array.isArray(value) ? value : [];
+        },
+        getExpandedDirectories() {
+            return expandedDirectories;
+        },
+        getKnownDirectories() {
+            return knownDirectories;
+        },
+        setStatus: undefined,
+        setConnectionStatus(connected) {
+            safeSetConnectionStatusHandler(connected);
+        },
+        updateHeader() {
+            safeUpdateHeader();
+        },
+        updateActionVisibility() {
+            safeUpdateActionVisibility();
+        },
+        updateActiveFileHighlight() {},
+        updateDocumentPanelTitle() {
+            safeUpdateDocumentPanelTitle();
+        },
+        buildQuery(params) {
+            return safeBuildQuery(params);
+        },
+        updateLocation(file, options = {}) {
+            safeUpdateLocation(file, options);
+        },
+        fallbackMarkdownFor(path) {
+            return safeFallbackMarkdownFor(path);
+        },
+        normaliseFileIndex(values) {
+            return safeNormaliseFileIndex(values);
+        },
+        buildTreeFromFlatList(list) {
+            return safeBuildTreeFromFlatList(list);
+        },
+        getCssNumber(variableName, fallback) {
+            return safeGetCssNumber(rootElement, variableName, fallback);
+        },
+    };
+
+    return sharedContext;
+}

--- a/frontend/src/js/unified_index.js
+++ b/frontend/src/js/unified_index.js
@@ -4,6 +4,7 @@ import { initEditor } from './editor/editor.js';
 import { initNavigation } from './files/navigation.js';
 import { createHandleDirectoryUpdate, createHandleFileChanged } from './files/realtime_handlers.js';
 import { createAppContext } from './app/context.js';
+import { createSharedContext } from './app/shared_context.js';
 import { createRealtimeService } from './services/realtime.js';
 import { createTerminalService } from './services/terminal.js';
 import {
@@ -60,8 +61,6 @@ function bootstrap() {
         terminalResizeHandle,
         panelToggleButtons,
     } = elements;
-    const { expandedDirectories, knownDirectories } = sets;
-
     const initialIndex = normaliseFileIndex({
         filesValue: initialState.files,
         treeValue: initialState.fileTree,
@@ -80,7 +79,8 @@ function bootstrap() {
     let editorApi = null;
     let tocController = null;
 
-    const sharedContext = {
+    const sharedContext = createSharedContext({
+        appState,
         elements: {
             content,
             fileName,
@@ -101,78 +101,27 @@ function bootstrap() {
             unsavedChangesDiscardButton,
             unsavedChangesCancelButton,
         },
-        getCurrentFile: () => appState.currentFile,
-        setCurrentFile(value, options = {}) {
-            const { silent = false } = options || {};
-            const nextValue = typeof value === 'string' && value.length ? value : value || null;
-            if (appState.currentFile === nextValue) {
-                return;
-            }
-            appState.currentFile = nextValue;
-            if (!silent) {
-                this.updateActiveFileHighlight();
-                this.updateHeader();
-                this.updateDocumentPanelTitle();
-            }
-        },
-        getCurrentContent: () => appState.currentContent,
-        setCurrentContent(value) {
-            appState.currentContent = typeof value === 'string' ? value : '';
-        },
-        hasPendingChanges: () => appState.hasPendingChanges,
-        setHasPendingChanges(value) {
+        sets,
+        applyHasPendingChanges(value) {
             if (headerController) {
                 headerController.applyHasPendingChanges(value);
-            } else {
-                const nextValue = Boolean(value);
-                if (nextValue !== appState.hasPendingChanges) {
-                    appState.hasPendingChanges = nextValue;
-                    document?.body?.classList?.toggle('document-has-pending-changes', nextValue);
-                }
-            }
-        },
-        isEditing: () => appState.isEditing,
-        setEditing(value) {
-            const next = Boolean(value);
-            if (appState.isEditing === next) {
                 return;
             }
-            appState.isEditing = next;
-            this.updateActionVisibility();
-        },
-        isPreviewing: () => appState.isPreviewing,
-        setPreviewing(value) {
-            const next = Boolean(value);
-            if (appState.isPreviewing === next) {
-                return;
+            const nextValue = Boolean(value);
+            if (nextValue !== appState.hasPendingChanges) {
+                appState.hasPendingChanges = nextValue;
+                document?.body?.classList?.toggle('document-has-pending-changes', nextValue);
             }
-            appState.isPreviewing = next;
-            this.updateActionVisibility();
         },
-        getResolvedRootPath: () => appState.resolvedRootPath,
-        setResolvedRootPath(value) {
-            appState.resolvedRootPath = typeof value === 'string' ? value : appState.resolvedRootPath;
+        setConnectionStatusHandler: (connected) => {
+            setConnectionStatusHandler(connected);
         },
-        getOriginalPathArgument: () => appState.originalPathArgument,
-        getFiles: () => appState.files,
-        setFiles: (value) => {
-            appState.files = Array.isArray(value) ? value : [];
-        },
-        getFileTree: () => appState.fileTree,
-        setFileTree: (value) => {
-            appState.fileTree = Array.isArray(value) ? value : [];
-        },
-        getExpandedDirectories: () => expandedDirectories,
-        getKnownDirectories: () => knownDirectories,
-        setStatus,
-        setConnectionStatus: (connected) => setConnectionStatusHandler(connected),
         updateHeader() {
             headerController?.updateHeader();
         },
         updateActionVisibility() {
             headerController?.updateActionVisibility();
         },
-        updateActiveFileHighlight() {},
         updateDocumentPanelTitle() {
             headerController?.updateDocumentPanelTitle();
         },
@@ -191,10 +140,18 @@ function bootstrap() {
             }
         },
         fallbackMarkdownFor,
-        normaliseFileIndex: (values) => normaliseFileIndex(values),
-        buildTreeFromFlatList: (list) => buildTreeFromFlatList(list),
-        getCssNumber: (variableName, fallback) => getCssNumber(rootElement, variableName, fallback),
-    };
+        normaliseFileIndex(values) {
+            return normaliseFileIndex(values);
+        },
+        buildTreeFromFlatList(list) {
+            return buildTreeFromFlatList(list);
+        },
+        getCssNumber(variableName, fallback) {
+            return getCssNumber(rootElement, variableName, fallback);
+        },
+        rootElement,
+    });
+    sharedContext.setStatus = setStatus;
     const markdownContext = {
         content,
         tocList,

--- a/frontend/tests/app/shared_context.test.js
+++ b/frontend/tests/app/shared_context.test.js
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+import { createSharedContext } from '../../src/js/app/shared_context.js';
+
+function createClassList() {
+    const values = new Set();
+    return {
+        toggle(value, force) {
+            if (force === undefined) {
+                if (values.has(value)) {
+                    values.delete(value);
+                    return false;
+                }
+                values.add(value);
+                return true;
+            }
+            if (force) {
+                values.add(value);
+                return true;
+            }
+            values.delete(value);
+            return false;
+        },
+        contains(value) {
+            return values.has(value);
+        },
+    };
+}
+
+function createAppState() {
+    return {
+        currentFile: null,
+        currentContent: '',
+        hasPendingChanges: false,
+        isEditing: false,
+        isPreviewing: false,
+        resolvedRootPath: '',
+        originalPathArgument: '',
+        files: [],
+        fileTree: [],
+    };
+}
+
+let originalDocument;
+
+beforeEach(() => {
+    originalDocument = global.document;
+});
+
+afterEach(() => {
+    global.document = originalDocument;
+});
+
+// Utility factory so each test can supply only the dependencies it cares about.
+function createSharedContextWithOverrides(overrides = {}) {
+    const appState = overrides.appState || createAppState();
+    const callbacks = overrides.callbacks || {};
+    const hasApplyOverride = Object.prototype.hasOwnProperty.call(overrides, 'applyHasPendingChanges');
+    const sharedContext = createSharedContext({
+        appState,
+        elements: overrides.elements || {},
+        sets: overrides.sets || { expandedDirectories: new Set(), knownDirectories: new Set() },
+        applyHasPendingChanges: hasApplyOverride
+            ? overrides.applyHasPendingChanges
+            : (value) => {
+                  callbacks.pendingCalls = (callbacks.pendingCalls || 0) + 1;
+                  appState.hasPendingChanges = Boolean(value);
+              },
+        setConnectionStatusHandler: overrides.setConnectionStatusHandler || (() => {}),
+        updateHeader:
+            overrides.updateHeader
+            || (() => {
+                callbacks.headerCalls = (callbacks.headerCalls || 0) + 1;
+            }),
+        updateActionVisibility:
+            overrides.updateActionVisibility
+            || (() => {
+                callbacks.actionCalls = (callbacks.actionCalls || 0) + 1;
+            }),
+        updateDocumentPanelTitle:
+            overrides.updateDocumentPanelTitle
+            || (() => {
+                callbacks.titleCalls = (callbacks.titleCalls || 0) + 1;
+            }),
+        buildQuery: overrides.buildQuery || ((params) => JSON.stringify(params)),
+        updateLocation:
+            overrides.updateLocation
+            || ((file, options = {}) => {
+                callbacks.location = { file, options };
+            }),
+        fallbackMarkdownFor: overrides.fallbackMarkdownFor || ((value) => value),
+        normaliseFileIndex: overrides.normaliseFileIndex || ((values) => values),
+        buildTreeFromFlatList: overrides.buildTreeFromFlatList || ((list) => list),
+        getCssNumber: overrides.getCssNumber || ((_, __, fallback) => fallback ?? 0),
+        rootElement: overrides.rootElement || {},
+    });
+
+    return { sharedContext, appState, callbacks };
+}
+
+test('setCurrentFile updates state and invokes callbacks when not silent', () => {
+    const events = [];
+    const { sharedContext, appState } = createSharedContextWithOverrides({
+        updateHeader: () => events.push('header'),
+        updateDocumentPanelTitle: () => events.push('title'),
+    });
+
+    sharedContext.updateActiveFileHighlight = () => events.push('highlight');
+
+    sharedContext.setCurrentFile('README.md');
+
+    assert.equal(appState.currentFile, 'README.md');
+    assert.deepEqual(events, ['highlight', 'header', 'title']);
+
+    events.length = 0;
+    sharedContext.setCurrentFile('CHANGELOG.md', { silent: true });
+    assert.equal(appState.currentFile, 'CHANGELOG.md');
+    assert.deepEqual(events, []);
+});
+
+test('setHasPendingChanges delegates to the provided callback', () => {
+    const pendingCalls = [];
+    const appState = createAppState();
+    const { sharedContext } = createSharedContextWithOverrides({
+        appState,
+        applyHasPendingChanges(value) {
+            pendingCalls.push(Boolean(value));
+            appState.hasPendingChanges = Boolean(value);
+        },
+    });
+
+    sharedContext.setHasPendingChanges(true);
+
+    assert.equal(appState.hasPendingChanges, true);
+    assert.deepEqual(pendingCalls, [true]);
+});
+
+test('setHasPendingChanges falls back to toggling the document class when no callback', () => {
+    const appState = createAppState();
+    const classList = createClassList();
+    global.document = { body: { classList } };
+
+    const { sharedContext } = createSharedContextWithOverrides({
+        appState,
+        applyHasPendingChanges: undefined,
+    });
+
+    sharedContext.setHasPendingChanges(true);
+    assert.equal(appState.hasPendingChanges, true);
+    assert.equal(classList.contains('document-has-pending-changes'), true);
+});


### PR DESCRIPTION
## Summary
- extract the shared context creation logic into a dedicated factory that accepts injected callbacks
- update the unified bootstrap to instantiate the new shared context and pass through existing DOM helpers
- add unit tests that verify the shared context setters trigger the expected delegates and fallbacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e29818a0d08328b6fa82563291aca5