### PR TITLE
Modularize unified viewer bootstrap lifecycle

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,22 @@
       },
       "devDependencies": {
         "esbuild": "^0.25.10",
+        "jsdom": "^24.0.0",
         "rimraf": "^5.0.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -36,6 +51,121 @@
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
       "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
       "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.10",
@@ -591,6 +721,16 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -617,6 +757,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -632,6 +779,20 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/character-entities": {
@@ -761,6 +922,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -793,6 +967,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cytoscape": {
       "version": "3.33.1",
@@ -1287,6 +1482,57 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.18",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
@@ -1310,6 +1556,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
@@ -1330,6 +1583,16 @@
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -1374,6 +1637,21 @@
       "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==",
       "license": "(MPL-2.0 OR Apache-2.0)"
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1393,6 +1671,68 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.10",
@@ -1468,6 +1808,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1475,6 +1842,45 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/github-markdown-css": {
@@ -1510,6 +1916,61 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "11.9.0",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
@@ -1517,6 +1978,47 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -1549,6 +2051,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1577,6 +2086,84 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/json-stringify-pretty-compact": {
       "version": "3.0.0",
@@ -1673,6 +2260,16 @@
       "license": "MIT",
       "peerDependencies": {
         "marked": ">= 4 < 17"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -2182,6 +2779,29 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -2249,12 +2869,32 @@
       "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
       "license": "MIT"
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -2282,6 +2922,36 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "18.2.0",
@@ -2317,6 +2987,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rimraf": {
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
@@ -2338,6 +3015,13 @@
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
       "license": "Unlicense"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rw": {
       "version": "1.3.3",
@@ -2362,6 +3046,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -2530,6 +3227,13 @@
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "license": "MIT"
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/topojson-client": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
@@ -2549,6 +3253,22 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -2582,6 +3302,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/uuid": {
@@ -3119,6 +3860,19 @@
         "vega-util": "^1.17.3"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-worker": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
@@ -3130,6 +3884,29 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -3254,6 +4031,45 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xterm": {
       "version": "5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "esbuild": "^0.25.10",
+    "jsdom": "^24.0.0",
     "rimraf": "^5.0.5"
   },
   "dependencies": {

--- a/frontend/src/js/app/unified_app.js
+++ b/frontend/src/js/app/unified_app.js
@@ -1,0 +1,279 @@
+export function createUnifiedApp({
+    context,
+    sharedContext,
+    layout,
+    controllers,
+    services,
+} = {}) {
+    if (!context || !sharedContext || !layout || !controllers || !services) {
+        throw new Error('createUnifiedApp requires context, sharedContext, layout, controllers, and services.');
+    }
+
+    const {
+        initialState = {},
+        state: appState = {},
+        elements = {},
+        terminalStorageKey,
+    } = context;
+
+    const {
+        dockviewRoot,
+        appShell,
+        viewerSection,
+        tocSidebar,
+        fileSidebar,
+        tocSplitter,
+        fileSplitter,
+        rootElement,
+        panelToggleButtons,
+        tocList,
+        terminalPanel,
+        terminalContainer,
+        terminalToggleButton,
+        terminalStatusText,
+        terminalResizeHandle,
+        content,
+    } = elements;
+
+    const {
+        initLayout,
+    } = layout;
+
+    const {
+        createHeaderController,
+        createTocController,
+        createRouter,
+    } = controllers;
+
+    const {
+        createTerminalService,
+        createRealtimeService,
+        createViewerApi,
+        initNavigation,
+        initEditor,
+        createHandleDirectoryUpdate,
+        createHandleFileChanged,
+        createResetViewToFallback,
+        setConnectionStatusHandler = () => {},
+    } = services;
+
+    let layoutInstance = null;
+    let headerController = null;
+    let tocCleanup = null;
+    let router = null;
+    let navigationApi = null;
+    let editorApi = null;
+    let viewerApi = null;
+    let realtimeService = null;
+    let terminalService = null;
+    let contentClickHandler = null;
+    let pointerListeners = [];
+
+    function attachPointerListeners() {
+        if (!layoutInstance?.dockviewIsActive || !dockviewRoot || !window) {
+            return;
+        }
+
+        const downListener = (event) => {
+            layoutInstance.handlePointerDown?.(event);
+        };
+        const finishListener = (event) => {
+            layoutInstance.handlePointerFinish?.(event);
+        };
+
+        dockviewRoot.addEventListener?.('pointerdown', downListener);
+        window.addEventListener?.('pointerup', finishListener);
+        window.addEventListener?.('pointercancel', finishListener);
+
+        pointerListeners = [
+            ['pointerdown', dockviewRoot, downListener],
+            ['pointerup', window, finishListener],
+            ['pointercancel', window, finishListener],
+        ];
+    }
+
+    function detachPointerListeners() {
+        pointerListeners.forEach(([eventName, target, handler]) => {
+            target?.removeEventListener?.(eventName, handler);
+        });
+        pointerListeners = [];
+    }
+
+    function start() {
+        layoutInstance = initLayout?.({
+            dockviewRoot,
+            appShell,
+            viewerSection,
+            tocSidebar,
+            fileSidebar,
+            terminalPanel,
+            tocSplitter,
+            fileSplitter,
+            rootElement,
+            panelToggleButtons,
+            getCurrentFile: () => sharedContext.getCurrentFile?.() ?? null,
+        }) ?? null;
+
+        const dockviewIsActive = Boolean(layoutInstance?.dockviewIsActive);
+        document?.body?.classList?.toggle?.('dockview-active', dockviewIsActive);
+        layoutInstance?.refreshPanelToggleStates?.();
+
+        headerController = createHeaderController?.({
+            elements: {
+                fileName: elements.fileName,
+                sidebarPath: elements.sidebarPath,
+                downloadButton: elements.downloadButton,
+                deleteButton: elements.deleteButton,
+                editButton: elements.editButton,
+                previewButton: elements.previewButton,
+                saveButton: elements.saveButton,
+                cancelButton: elements.cancelButton,
+            },
+            layout: layoutInstance,
+            appState,
+        }) ?? null;
+        if (sharedContext.controllers) {
+            sharedContext.controllers.header = headerController;
+        }
+
+        const tocController = createTocController?.({ tocList }) ?? null;
+        tocCleanup = tocController?.attach?.() ?? null;
+
+        attachPointerListeners();
+
+        sharedContext.layout = layoutInstance;
+
+        let resetViewToFallback = null;
+
+        router = createRouter?.({
+            appState,
+            getCurrentFile: () => sharedContext.getCurrentFile?.() ?? null,
+            onNavigate: (targetFile, options) => {
+                if (typeof navigationApi?.loadFile === 'function') {
+                    void navigationApi.loadFile(targetFile, options);
+                }
+            },
+            onFallback: (options) => {
+                if (typeof resetViewToFallback === 'function') {
+                    resetViewToFallback(options);
+                }
+            },
+        }) ?? null;
+        sharedContext.router = router;
+
+        context.initialFileFromLocation = router?.getCurrent?.() ?? null;
+
+        terminalService = createTerminalService?.({
+            terminalPanel,
+            terminalContainer,
+            terminalToggleButton,
+            terminalStatusText,
+            terminalResizeHandle,
+            storageKey: terminalStorageKey,
+            isDockviewActive: () => Boolean(layoutInstance?.dockviewIsActive),
+        }) ?? null;
+
+        viewerApi = createViewerApi?.(sharedContext.markdownContext) ?? null;
+        navigationApi = initNavigation?.(sharedContext, viewerApi) ?? null;
+        editorApi = initEditor?.(sharedContext, viewerApi, navigationApi) ?? null;
+
+        navigationApi?.bindEditorApi?.(editorApi);
+        if (typeof navigationApi?.updateActiveFileHighlight === 'function') {
+            sharedContext.updateActiveFileHighlight = () => navigationApi.updateActiveFileHighlight();
+        }
+
+        resetViewToFallback = createResetViewToFallback?.({
+            sharedContext,
+            viewerApi,
+            editorApi,
+        }) ?? null;
+
+        if (content && typeof editorApi?.handleHeadingActionClick === 'function') {
+            contentClickHandler = (event) => {
+                editorApi.handleHeadingActionClick(event);
+            };
+            content.addEventListener('click', contentClickHandler);
+        }
+
+        const handleDirectoryUpdate = createHandleDirectoryUpdate?.({
+            navigationApi,
+            sharedContext,
+            resetViewToFallback,
+        });
+        const handleFileChanged = createHandleFileChanged?.({
+            navigationApi,
+            sharedContext,
+        });
+
+        realtimeService = createRealtimeService?.({
+            getSubscriptionPath: () => appState.originalPathArgument,
+            onConnectionChange: (connected) => {
+                setConnectionStatusHandler(connected);
+            },
+            onDirectoryUpdate: handleDirectoryUpdate,
+            onFileChanged: handleFileChanged,
+        }) ?? null;
+
+        function initialise() {
+            const fallback = sharedContext.fallbackMarkdownFor?.(
+                appState.resolvedRootPath || appState.originalPathArgument || 'the selected path'
+            );
+            viewerApi?.render?.(initialState.content || fallback, { updateCurrent: true });
+            navigationApi?.renderFileList?.();
+            sharedContext.updateHeader?.();
+            if (initialState.error) {
+                sharedContext.setStatus?.(initialState.error);
+            }
+            terminalService?.setupTerminalPanel?.();
+            realtimeService?.connect?.();
+
+            const filesList = sharedContext.getFiles?.() || [];
+            if (!sharedContext.getCurrentFile?.() && filesList.length) {
+                sharedContext.setCurrentFile?.(filesList[0].relativePath);
+            }
+
+            const currentPath = sharedContext.getCurrentFile?.();
+            if (!context.initialFileFromLocation && currentPath) {
+                void navigationApi?.loadFile?.(currentPath, { replaceHistory: true });
+            }
+        }
+
+        initialise();
+
+        if (context.initialFileFromLocation) {
+            void navigationApi?.loadFile?.(context.initialFileFromLocation, { replaceHistory: true });
+        }
+
+        return { router, layoutInstance };
+    }
+
+    function destroy() {
+        detachPointerListeners();
+
+        if (tocCleanup) {
+            tocCleanup();
+            tocCleanup = null;
+        }
+
+        if (content && contentClickHandler) {
+            content.removeEventListener('click', contentClickHandler);
+            contentClickHandler = null;
+        }
+
+        router?.dispose?.();
+        realtimeService?.disconnect?.();
+
+        if (sharedContext.controllers) {
+            sharedContext.controllers.header = null;
+        }
+        sharedContext.router = null;
+
+        if (document?.body?.classList?.contains?.('dockview-active')) {
+            document.body.classList.remove('dockview-active');
+        }
+
+        sharedContext.layout = null;
+    }
+
+    return { start, destroy };
+}

--- a/frontend/src/js/unified_index.js
+++ b/frontend/src/js/unified_index.js
@@ -4,6 +4,7 @@ import { initEditor } from './editor/editor.js';
 import { initNavigation } from './files/navigation.js';
 import { createHandleDirectoryUpdate, createHandleFileChanged } from './files/realtime_handlers.js';
 import { createAppContext } from './app/context.js';
+import { createUnifiedApp } from './app/unified_app.js';
 import { createRealtimeService } from './services/realtime.js';
 import { createTerminalService } from './services/terminal.js';
 import {
@@ -21,9 +22,9 @@ import { createRouter } from './app/router.js';
 import { createTocController } from './app/toc_controller.js';
 
 // Client-side bootstrap logic for the unified markdown viewer UI.
-function bootstrap() {
+function composeUnifiedApp() {
     const context = createAppContext();
-    const { initialState, state: appState, elements, sets, terminalStorageKey } = context;
+    const { initialState, state: appState, elements, sets } = context;
     const {
         content,
         fileName,
@@ -73,14 +74,12 @@ function bootstrap() {
     context.initialFileFromLocation = null;
 
     const setConnectionStatusHandler = createSetConnectionStatus(offlineOverlay);
-    let resetViewToFallback = () => {};
-    let headerController = null;
-    let router = null;
-    let navigationApi = null;
-    let editorApi = null;
-    let tocController = null;
 
     const sharedContext = {
+        controllers: {
+            header: null,
+        },
+        router: null,
         elements: {
             content,
             fileName,
@@ -121,8 +120,9 @@ function bootstrap() {
         },
         hasPendingChanges: () => appState.hasPendingChanges,
         setHasPendingChanges(value) {
-            if (headerController) {
-                headerController.applyHasPendingChanges(value);
+            const header = this.controllers?.header;
+            if (header) {
+                header.applyHasPendingChanges(value);
             } else {
                 const nextValue = Boolean(value);
                 if (nextValue !== appState.hasPendingChanges) {
@@ -167,27 +167,30 @@ function bootstrap() {
         setStatus,
         setConnectionStatus: (connected) => setConnectionStatusHandler(connected),
         updateHeader() {
-            headerController?.updateHeader();
+            const header = this.controllers?.header;
+            header?.updateHeader();
         },
         updateActionVisibility() {
-            headerController?.updateActionVisibility();
+            const header = this.controllers?.header;
+            header?.updateActionVisibility();
         },
         updateActiveFileHighlight() {},
         updateDocumentPanelTitle() {
-            headerController?.updateDocumentPanelTitle();
+            const header = this.controllers?.header;
+            header?.updateDocumentPanelTitle();
         },
         buildQuery(params) {
-            return router ? router.buildQuery(params) : '';
+            return this.router ? this.router.buildQuery(params) : '';
         },
         updateLocation(file, options = {}) {
-            if (!router) {
+            if (!this.router) {
                 return;
             }
             const { replace = false } = options;
             if (replace) {
-                router.replace(file);
+                this.router.replace(file);
             } else {
-                router.push(file);
+                this.router.push(file);
             }
         },
         fallbackMarkdownFor,
@@ -206,144 +209,40 @@ function bootstrap() {
     };
     sharedContext.markdownContext = markdownContext;
 
-    const layout = initLayout({
-        dockviewRoot,
-        appShell,
-        viewerSection,
-        tocSidebar,
-        fileSidebar,
-        terminalPanel,
-        tocSplitter,
-        fileSplitter,
-        rootElement,
-        panelToggleButtons,
-        getCurrentFile: () => sharedContext.getCurrentFile(),
-    });
-    const dockviewIsActive = layout.dockviewIsActive;
-    document.body.classList.toggle('dockview-active', dockviewIsActive);
-    layout.refreshPanelToggleStates();
-
-    headerController = createHeaderController({
-        elements: {
-            fileName,
-            sidebarPath,
-            downloadButton,
-            deleteButton,
-            editButton,
-            previewButton,
-            saveButton,
-            cancelButton,
-        },
-        layout,
-        appState,
-    });
-
-    tocController = createTocController({ tocList });
-    tocController.attach();
-
-    if (dockviewIsActive && dockviewRoot) {
-        dockviewRoot.addEventListener('pointerdown', layout.handlePointerDown);
-        window.addEventListener('pointerup', layout.handlePointerFinish);
-        window.addEventListener('pointercancel', layout.handlePointerFinish);
-    }
-
-    sharedContext.layout = layout;
-
-    router = createRouter({
-        appState,
-        getCurrentFile: () => sharedContext.getCurrentFile(),
-        onNavigate: (targetFile, options) => {
-            if (typeof navigationApi?.loadFile === 'function') {
-                void navigationApi.loadFile(targetFile, options);
-            }
-        },
-        onFallback: (options) => {
-            resetViewToFallback(options);
-        },
-    });
-
-    context.initialFileFromLocation = router.getCurrent();
-
-    const terminalService = createTerminalService({
-        terminalPanel,
-        terminalContainer,
-        terminalToggleButton,
-        terminalStatusText,
-        terminalResizeHandle,
-        storageKey: terminalStorageKey,
-        isDockviewActive: () => layout.dockviewIsActive,
-    });
-
-    const viewerApi = createViewerApi(markdownContext);
-
-    navigationApi = initNavigation(sharedContext, viewerApi);
-    editorApi = initEditor(sharedContext, viewerApi, navigationApi);
-    if (typeof navigationApi?.bindEditorApi === 'function') {
-        navigationApi.bindEditorApi(editorApi);
-    }
-    if (typeof navigationApi?.updateActiveFileHighlight === 'function') {
-        sharedContext.updateActiveFileHighlight = () => navigationApi.updateActiveFileHighlight();
-    }
-
-    resetViewToFallback = createResetViewToFallback({ sharedContext, viewerApi, editorApi });
-
-    if (content && typeof editorApi?.handleHeadingActionClick === 'function') {
-        content.addEventListener('click', (event) => {
-            editorApi.handleHeadingActionClick(event);
-        });
-    }
-
-    const handleDirectoryUpdate = createHandleDirectoryUpdate({
-        navigationApi,
+    const unifiedApp = createUnifiedApp({
+        context,
         sharedContext,
-        resetViewToFallback,
-    });
-    const handleFileChanged = createHandleFileChanged({
-        navigationApi,
-        sharedContext,
-    });
-
-    const realtimeService = createRealtimeService({
-        getSubscriptionPath: () => appState.originalPathArgument,
-        onConnectionChange: (connected) => {
-            setConnectionStatusHandler(connected);
+        layout: {
+            initLayout,
         },
-        onDirectoryUpdate: handleDirectoryUpdate,
-        onFileChanged: handleFileChanged,
+        controllers: {
+            createHeaderController,
+            createTocController,
+            createRouter,
+        },
+        services: {
+            createTerminalService,
+            createRealtimeService,
+            createViewerApi,
+            initNavigation,
+            initEditor,
+            createHandleDirectoryUpdate,
+            createHandleFileChanged,
+            createResetViewToFallback,
+            setConnectionStatusHandler,
+        },
     });
 
-    function initialise() {
-        const initialFallback = fallbackMarkdownFor(
-            appState.resolvedRootPath || appState.originalPathArgument || 'the selected path'
-        );
-        viewerApi.render(initialState.content || initialFallback, { updateCurrent: true });
-        navigationApi.renderFileList();
-        sharedContext.updateHeader();
-        if (initialState.error) {
-            setStatus(initialState.error);
-        }
-        terminalService.setupTerminalPanel();
-        realtimeService.connect();
-        const filesList = sharedContext.getFiles();
-        if (!sharedContext.getCurrentFile() && filesList.length) {
-            sharedContext.setCurrentFile(filesList[0].relativePath);
-        }
+    return unifiedApp;
+}
 
-        const currentPath = sharedContext.getCurrentFile();
-        if (!context.initialFileFromLocation && currentPath) {
-            void navigationApi.loadFile(currentPath, { replaceHistory: true });
-        }
-    }
-
-    initialise();
-
-    if (context.initialFileFromLocation) {
-        void navigationApi.loadFile(context.initialFileFromLocation, { replaceHistory: true });
-    }
+function startUnifiedApp() {
+    const app = composeUnifiedApp();
+    app.start();
 }
 
 if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', bootstrap, { once: true });
+    document.addEventListener('DOMContentLoaded', startUnifiedApp, { once: true });
 } else {
-    bootstrap();
+    startUnifiedApp();
 }

--- a/frontend/tests/app/unified_app.test.js
+++ b/frontend/tests/app/unified_app.test.js
@@ -1,0 +1,300 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+import { JSDOM } from 'jsdom';
+import { createUnifiedApp } from '../../src/js/app/unified_app.js';
+
+function createTrackedTarget(element) {
+    const listeners = new Map();
+    return Object.assign(element, {
+        _listeners: listeners,
+        addEventListener(type, handler) {
+            listeners.set(type, handler);
+        },
+        removeEventListener(type, handler) {
+            if (listeners.get(type) === handler) {
+                listeners.delete(type);
+            }
+        },
+    });
+}
+
+let dom;
+let originalWindow;
+let originalDocument;
+
+beforeEach(() => {
+    dom = new JSDOM(`<!doctype html><html><body></body></html>`, { url: 'https://example.com/viewer' });
+    originalWindow = global.window;
+    originalDocument = global.document;
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.requestAnimationFrame = (cb) => {
+        if (typeof cb === 'function') {
+            cb();
+        }
+        return 1;
+    };
+    dom.window.cancelAnimationFrame = () => {};
+});
+
+afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    dom.window.close();
+});
+
+function createContext() {
+    const documentRef = dom.window.document;
+
+    const elements = {
+        content: createTrackedTarget(documentRef.createElement('div')),
+        fileName: documentRef.createElement('div'),
+        sidebarPath: documentRef.createElement('div'),
+        fileList: documentRef.createElement('div'),
+        downloadButton: documentRef.createElement('button'),
+        deleteButton: documentRef.createElement('button'),
+        editButton: documentRef.createElement('button'),
+        previewButton: documentRef.createElement('button'),
+        saveButton: documentRef.createElement('button'),
+        cancelButton: documentRef.createElement('button'),
+        editorContainer: documentRef.createElement('div'),
+        offlineOverlay: documentRef.createElement('div'),
+        unsavedChangesModal: documentRef.createElement('div'),
+        unsavedChangesFilename: documentRef.createElement('div'),
+        unsavedChangesMessage: documentRef.createElement('div'),
+        unsavedChangesDetail: documentRef.createElement('div'),
+        unsavedChangesSaveButton: documentRef.createElement('button'),
+        unsavedChangesDiscardButton: documentRef.createElement('button'),
+        unsavedChangesCancelButton: documentRef.createElement('button'),
+        tocList: documentRef.createElement('ul'),
+        tocSidebar: documentRef.createElement('div'),
+        fileSidebar: documentRef.createElement('div'),
+        tocSplitter: documentRef.createElement('div'),
+        fileSplitter: documentRef.createElement('div'),
+        dockviewRoot: createTrackedTarget(documentRef.createElement('div')),
+        appShell: documentRef.createElement('div'),
+        rootElement: documentRef.documentElement,
+        viewerSection: documentRef.createElement('section'),
+        terminalPanel: documentRef.createElement('div'),
+        terminalContainer: documentRef.createElement('div'),
+        terminalToggleButton: documentRef.createElement('button'),
+        terminalStatusText: documentRef.createElement('div'),
+        terminalResizeHandle: documentRef.createElement('div'),
+        panelToggleButtons: [],
+    };
+
+    const initialState = {
+        content: '# Hello world',
+        files: [],
+        fileTree: [],
+        selectedFile: null,
+        error: null,
+        rootPath: '',
+        pathArgument: '',
+    };
+
+    const state = {
+        currentFile: null,
+        files: [],
+        fileTree: [],
+        websocket: null,
+        reconnectTimer: null,
+        isEditing: false,
+        isPreviewing: false,
+        currentContent: '',
+        hasPendingChanges: false,
+        resolvedRootPath: '',
+        originalPathArgument: '',
+    };
+
+    return {
+        context: {
+            initialState,
+            elements,
+            state,
+            sets: {
+                expandedDirectories: new Set(),
+                knownDirectories: new Set(),
+            },
+            terminalStorageKey: 'terminal-test',
+            initialFileFromLocation: null,
+        },
+        elements,
+        state,
+    };
+}
+
+test('start wires listeners and destroy unwires them', () => {
+    const { context, elements, state } = createContext();
+    const files = [{ relativePath: 'README.md' }];
+    state.files = files;
+
+    const sharedContext = {
+        controllers: { header: null },
+        router: null,
+        elements: context.elements,
+        getCurrentFile: () => state.currentFile,
+        setCurrentFile(value) {
+            state.currentFile = value;
+        },
+        getCurrentContent: () => state.currentContent,
+        setCurrentContent(value) {
+            state.currentContent = value;
+        },
+        hasPendingChanges: () => state.hasPendingChanges,
+        setHasPendingChanges() {},
+        isEditing: () => state.isEditing,
+        setEditing() {},
+        isPreviewing: () => state.isPreviewing,
+        setPreviewing() {},
+        getResolvedRootPath: () => state.resolvedRootPath,
+        setResolvedRootPath(value) {
+            state.resolvedRootPath = value;
+        },
+        getOriginalPathArgument: () => state.originalPathArgument,
+        getFiles: () => state.files,
+        setFiles(value) {
+            state.files = Array.isArray(value) ? value : [];
+        },
+        getFileTree: () => state.fileTree,
+        setFileTree(value) {
+            state.fileTree = Array.isArray(value) ? value : [];
+        },
+        getExpandedDirectories: () => context.sets.expandedDirectories,
+        getKnownDirectories: () => context.sets.knownDirectories,
+        setStatus() {},
+        setConnectionStatus() {},
+        updateHeader() {},
+        updateActionVisibility() {},
+        updateActiveFileHighlight() {},
+        updateDocumentPanelTitle() {},
+        buildQuery: () => '',
+        updateLocation() {},
+        fallbackMarkdownFor: () => '# fallback',
+        normaliseFileIndex: (values) => values,
+        buildTreeFromFlatList: (list) => list,
+        getCssNumber: () => 0,
+        markdownContext: {},
+    };
+
+    const layoutCalls = { refresh: 0 };
+    const pointerEvents = new Map();
+    const windowRef = dom.window;
+    const originalWindowAdd = windowRef.addEventListener.bind(windowRef);
+    const originalWindowRemove = windowRef.removeEventListener.bind(windowRef);
+    windowRef.addEventListener = (type, handler) => {
+        pointerEvents.set(type, handler);
+        originalWindowAdd(type, handler);
+    };
+    windowRef.removeEventListener = (type, handler) => {
+        if (pointerEvents.get(type) === handler) {
+            pointerEvents.delete(type);
+        }
+        originalWindowRemove(type, handler);
+    };
+
+    const dockviewRoot = elements.dockviewRoot;
+
+    const layout = {
+        initLayout: () => ({
+            dockviewIsActive: true,
+            refreshPanelToggleStates() {
+                layoutCalls.refresh += 1;
+            },
+            handlePointerDown() {},
+            handlePointerFinish() {},
+        }),
+    };
+
+    let routerDisposed = false;
+    const controllers = {
+        createHeaderController: () => ({
+            updateHeader() {},
+            updateActionVisibility() {},
+            updateDocumentPanelTitle() {},
+            applyHasPendingChanges() {},
+        }),
+        createTocController: () => ({
+            attach: () => () => {},
+        }),
+        createRouter: () => ({
+            buildQuery: () => '?file=README.md',
+            push() {},
+            replace() {},
+            getCurrent: () => 'README.md',
+            dispose() {
+                routerDisposed = true;
+            },
+        }),
+    };
+
+    let terminalSetup = 0;
+    const realtimeEvents = [];
+    let disconnectCalled = 0;
+    const services = {
+        createTerminalService: () => ({
+            setupTerminalPanel() {
+                terminalSetup += 1;
+            },
+        }),
+        createRealtimeService: (options) => {
+            realtimeEvents.push(options);
+            return {
+                connect() {
+                    realtimeEvents.push('connect');
+                },
+                disconnect() {
+                    disconnectCalled += 1;
+                },
+            };
+        },
+        createViewerApi: () => ({
+            render() {},
+        }),
+        initNavigation: () => ({
+            renderFileList() {},
+            loadFile() {},
+            bindEditorApi() {},
+            updateActiveFileHighlight() {},
+        }),
+        initEditor: () => ({
+            handleHeadingActionClick() {},
+        }),
+        createHandleDirectoryUpdate: () => () => {},
+        createHandleFileChanged: () => () => {},
+        createResetViewToFallback: () => () => {},
+        setConnectionStatusHandler: () => {},
+    };
+
+    const app = createUnifiedApp({
+        context,
+        sharedContext,
+        layout,
+        controllers,
+        services,
+    });
+
+    app.start();
+
+    assert.equal(dom.window.document.body.classList.contains('dockview-active'), true);
+    assert.equal(layoutCalls.refresh, 1);
+    assert.equal(dockviewRoot._listeners.has('pointerdown'), true);
+    assert.equal(pointerEvents.has('pointerup'), true);
+    assert.equal(terminalSetup, 1);
+    assert.equal(realtimeEvents.includes('connect'), true);
+    assert.equal(elements.content._listeners.has('click'), true);
+    assert.equal(state.currentFile, 'README.md');
+    assert.equal(typeof sharedContext.router?.getCurrent, 'function');
+    assert.equal(sharedContext.controllers.header !== null, true);
+
+    app.destroy();
+
+    assert.equal(dockviewRoot._listeners.size, 0);
+    assert.equal(pointerEvents.size, 0);
+    assert.equal(disconnectCalled, 1);
+    assert.equal(routerDisposed, true);
+    assert.equal(sharedContext.router, null);
+    assert.equal(sharedContext.controllers.header, null);
+    assert.equal(elements.content._listeners.size, 0);
+    assert.equal(dom.window.document.body.classList.contains('dockview-active'), false);
+});


### PR DESCRIPTION
## Summary
- introduce a dedicated `createUnifiedApp` module that coordinates layout setup, service wiring, and teardown routines for the unified viewer
- streamline `unified_index.js` to build the shared context and delegate startup to the modular app entry point
- add a JSDOM-based smoke test for the new lifecycle module and bring in the `jsdom` dev dependency to support it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e29815e7288328a5aca50d76a9b071