### PR TITLE
Refactor shared context into factory

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build:js": "esbuild src/js/unified_index.js src/js/print_view.js --bundle --minify --sourcemap --target=es2018 --outdir=../templates/static/dist --inject:src/js/process_shim.js '--define:process.env.NODE_ENV=\"production\"'",
     "build:css": "esbuild src/css/app.css src/css/print.css --bundle --minify --outdir=../templates/static/dist --loader:.woff2=file --loader:.woff=file --loader:.ttf=file",
     "clean": "rimraf ../templates/static/dist",
-    "test": "node --test"
+    "test": "node --test tests/app ../tests/frontend/app"
   },
   "devDependencies": {
     "esbuild": "^0.25.10",

--- a/frontend/src/js/app/shared_context.js
+++ b/frontend/src/js/app/shared_context.js
@@ -1,0 +1,225 @@
+// Provides a factory for the shared application context that wires state setters
+// to DOM-manipulating callbacks supplied by the bootstrap layer.
+export function createSharedContext({
+    appState,
+    elements = {},
+    sets = {},
+    applyHasPendingChanges,
+    setConnectionStatusHandler,
+    updateHeader,
+    updateActionVisibility,
+    updateDocumentPanelTitle,
+    buildQuery,
+    updateLocation,
+    fallbackMarkdownFor,
+    normaliseFileIndex,
+    buildTreeFromFlatList,
+    getCssNumber,
+    rootElement,
+    setStatus,
+} = {}) {
+    if (!appState) {
+        throw new Error('appState is required to create the shared context.');
+    }
+    if (!sets) {
+        throw new Error('sets are required to create the shared context.');
+    }
+
+    const {
+        content,
+        fileName,
+        sidebarPath,
+        fileList,
+        downloadButton,
+        deleteButton,
+        editButton,
+        previewButton,
+        saveButton,
+        cancelButton,
+        editorContainer,
+        unsavedChangesModal,
+        unsavedChangesFilename,
+        unsavedChangesMessage,
+        unsavedChangesDetail,
+        unsavedChangesSaveButton,
+        unsavedChangesDiscardButton,
+        unsavedChangesCancelButton,
+    } = elements;
+
+    const expandedDirectories = sets.expandedDirectories ?? new Set();
+    const knownDirectories = sets.knownDirectories ?? new Set();
+
+    const invokeUpdateHeader = typeof updateHeader === 'function' ? updateHeader : () => {};
+    const invokeUpdateActionVisibility = typeof updateActionVisibility === 'function'
+        ? updateActionVisibility
+        : () => {};
+    const invokeUpdateDocumentTitle = typeof updateDocumentPanelTitle === 'function'
+        ? updateDocumentPanelTitle
+        : () => {};
+    const invokeApplyPendingChanges = typeof applyHasPendingChanges === 'function'
+        ? (value) => applyHasPendingChanges(Boolean(value))
+        : () => {};
+    const invokeConnectionStatus = typeof setConnectionStatusHandler === 'function'
+        ? setConnectionStatusHandler
+        : () => {};
+    const invokeBuildQuery = typeof buildQuery === 'function' ? buildQuery : () => '';
+    const invokeUpdateLocation = typeof updateLocation === 'function' ? updateLocation : () => {};
+    const invokeFallbackMarkdownFor = typeof fallbackMarkdownFor === 'function'
+        ? fallbackMarkdownFor
+        : () => '';
+    const invokeNormaliseFileIndex = typeof normaliseFileIndex === 'function'
+        ? normaliseFileIndex
+        : (value) => value;
+    const invokeBuildTreeFromFlatList = typeof buildTreeFromFlatList === 'function'
+        ? buildTreeFromFlatList
+        : (value) => value;
+    const invokeGetCssNumber = typeof getCssNumber === 'function'
+        ? (variableName, fallbackValue) => getCssNumber(rootElement, variableName, fallbackValue)
+        : (_, fallbackValue) => fallbackValue;
+    const invokeSetStatus = typeof setStatus === 'function' ? setStatus : () => {};
+
+    const sharedContext = {
+        controllers: {
+            header: null,
+        },
+        router: null,
+        elements: {
+            content,
+            fileName,
+            sidebarPath,
+            fileList,
+            downloadButton,
+            deleteButton,
+            editButton,
+            previewButton,
+            saveButton,
+            cancelButton,
+            editorContainer,
+            unsavedChangesModal,
+            unsavedChangesFilename,
+            unsavedChangesMessage,
+            unsavedChangesDetail,
+            unsavedChangesSaveButton,
+            unsavedChangesDiscardButton,
+            unsavedChangesCancelButton,
+        },
+        getCurrentFile: () => appState.currentFile,
+        setCurrentFile(value, options = {}) {
+            const { silent = false } = options || {};
+            const nextValue = typeof value === 'string' && value.length ? value : value || null;
+            if (appState.currentFile === nextValue) {
+                return;
+            }
+            appState.currentFile = nextValue;
+            if (!silent) {
+                this.updateActiveFileHighlight();
+                this.updateHeader();
+                this.updateDocumentPanelTitle();
+            }
+        },
+        getCurrentContent: () => appState.currentContent,
+        setCurrentContent(value) {
+            appState.currentContent = typeof value === 'string' ? value : '';
+        },
+        hasPendingChanges: () => appState.hasPendingChanges,
+        setHasPendingChanges(value) {
+            const header = this.controllers?.header;
+            if (typeof header?.applyHasPendingChanges === 'function') {
+                header.applyHasPendingChanges(value);
+                return;
+            }
+            const nextValue = Boolean(value);
+            if (nextValue === appState.hasPendingChanges) {
+                return;
+            }
+            appState.hasPendingChanges = nextValue;
+            invokeApplyPendingChanges(nextValue);
+        },
+        isEditing: () => appState.isEditing,
+        setEditing(value) {
+            const next = Boolean(value);
+            if (appState.isEditing === next) {
+                return;
+            }
+            appState.isEditing = next;
+            this.updateActionVisibility();
+        },
+        isPreviewing: () => appState.isPreviewing,
+        setPreviewing(value) {
+            const next = Boolean(value);
+            if (appState.isPreviewing === next) {
+                return;
+            }
+            appState.isPreviewing = next;
+            this.updateActionVisibility();
+        },
+        getResolvedRootPath: () => appState.resolvedRootPath,
+        setResolvedRootPath(value) {
+            if (typeof value === 'string') {
+                appState.resolvedRootPath = value;
+            }
+        },
+        getOriginalPathArgument: () => appState.originalPathArgument,
+        getFiles: () => appState.files,
+        setFiles(value) {
+            appState.files = Array.isArray(value) ? value : [];
+        },
+        getFileTree: () => appState.fileTree,
+        setFileTree(value) {
+            appState.fileTree = Array.isArray(value) ? value : [];
+        },
+        getExpandedDirectories: () => expandedDirectories,
+        getKnownDirectories: () => knownDirectories,
+        setStatus: invokeSetStatus,
+        setConnectionStatus: (connected) => invokeConnectionStatus(connected),
+        updateHeader() {
+            const header = this.controllers?.header;
+            if (typeof header?.updateHeader === 'function') {
+                header.updateHeader();
+                return;
+            }
+            invokeUpdateHeader();
+        },
+        updateActionVisibility() {
+            const header = this.controllers?.header;
+            if (typeof header?.updateActionVisibility === 'function') {
+                header.updateActionVisibility();
+                return;
+            }
+            invokeUpdateActionVisibility();
+        },
+        updateActiveFileHighlight() {},
+        updateDocumentPanelTitle() {
+            const header = this.controllers?.header;
+            if (typeof header?.updateDocumentPanelTitle === 'function') {
+                header.updateDocumentPanelTitle();
+                return;
+            }
+            invokeUpdateDocumentTitle();
+        },
+        buildQuery(params) {
+            if (this.router && typeof this.router.buildQuery === 'function') {
+                return this.router.buildQuery(params);
+            }
+            return invokeBuildQuery(params);
+        },
+        updateLocation(file, options = {}) {
+            if (this.router) {
+                const { replace = false } = options || {};
+                if (replace && typeof this.router.replace === 'function') {
+                    this.router.replace(file);
+                } else if (typeof this.router.push === 'function') {
+                    this.router.push(file);
+                }
+                return;
+            }
+            invokeUpdateLocation(file, options);
+        },
+        fallbackMarkdownFor: invokeFallbackMarkdownFor,
+        normaliseFileIndex: (values) => invokeNormaliseFileIndex(values),
+        buildTreeFromFlatList: (list) => invokeBuildTreeFromFlatList(list),
+        getCssNumber: (variableName, fallbackValue) => invokeGetCssNumber(variableName, fallbackValue),
+    };
+
+    return sharedContext;
+}

--- a/frontend/src/js/unified_index.js
+++ b/frontend/src/js/unified_index.js
@@ -5,6 +5,7 @@ import { initNavigation } from './files/navigation.js';
 import { createHandleDirectoryUpdate, createHandleFileChanged } from './files/realtime_handlers.js';
 import { createAppContext } from './app/context.js';
 import { createUnifiedApp } from './app/unified_app.js';
+import { createSharedContext } from './app/shared_context.js';
 import { createRealtimeService } from './services/realtime.js';
 import { createTerminalService } from './services/terminal.js';
 import {
@@ -75,11 +76,12 @@ function composeUnifiedApp() {
 
     const setConnectionStatusHandler = createSetConnectionStatus(offlineOverlay);
 
-    const sharedContext = {
-        controllers: {
-            header: null,
-        },
-        router: null,
+    const applyHasPendingChanges = (value) => {
+        document?.body?.classList?.toggle('document-has-pending-changes', Boolean(value));
+    };
+
+    const sharedContext = createSharedContext({
+        appState,
         elements: {
             content,
             fileName,
@@ -100,104 +102,21 @@ function composeUnifiedApp() {
             unsavedChangesDiscardButton,
             unsavedChangesCancelButton,
         },
-        getCurrentFile: () => appState.currentFile,
-        setCurrentFile(value, options = {}) {
-            const { silent = false } = options || {};
-            const nextValue = typeof value === 'string' && value.length ? value : value || null;
-            if (appState.currentFile === nextValue) {
-                return;
-            }
-            appState.currentFile = nextValue;
-            if (!silent) {
-                this.updateActiveFileHighlight();
-                this.updateHeader();
-                this.updateDocumentPanelTitle();
-            }
-        },
-        getCurrentContent: () => appState.currentContent,
-        setCurrentContent(value) {
-            appState.currentContent = typeof value === 'string' ? value : '';
-        },
-        hasPendingChanges: () => appState.hasPendingChanges,
-        setHasPendingChanges(value) {
-            const header = this.controllers?.header;
-            if (header) {
-                header.applyHasPendingChanges(value);
-            } else {
-                const nextValue = Boolean(value);
-                if (nextValue !== appState.hasPendingChanges) {
-                    appState.hasPendingChanges = nextValue;
-                    document?.body?.classList?.toggle('document-has-pending-changes', nextValue);
-                }
-            }
-        },
-        isEditing: () => appState.isEditing,
-        setEditing(value) {
-            const next = Boolean(value);
-            if (appState.isEditing === next) {
-                return;
-            }
-            appState.isEditing = next;
-            this.updateActionVisibility();
-        },
-        isPreviewing: () => appState.isPreviewing,
-        setPreviewing(value) {
-            const next = Boolean(value);
-            if (appState.isPreviewing === next) {
-                return;
-            }
-            appState.isPreviewing = next;
-            this.updateActionVisibility();
-        },
-        getResolvedRootPath: () => appState.resolvedRootPath,
-        setResolvedRootPath(value) {
-            appState.resolvedRootPath = typeof value === 'string' ? value : appState.resolvedRootPath;
-        },
-        getOriginalPathArgument: () => appState.originalPathArgument,
-        getFiles: () => appState.files,
-        setFiles: (value) => {
-            appState.files = Array.isArray(value) ? value : [];
-        },
-        getFileTree: () => appState.fileTree,
-        setFileTree: (value) => {
-            appState.fileTree = Array.isArray(value) ? value : [];
-        },
-        getExpandedDirectories: () => expandedDirectories,
-        getKnownDirectories: () => knownDirectories,
-        setStatus,
-        setConnectionStatus: (connected) => setConnectionStatusHandler(connected),
-        updateHeader() {
-            const header = this.controllers?.header;
-            header?.updateHeader();
-        },
-        updateActionVisibility() {
-            const header = this.controllers?.header;
-            header?.updateActionVisibility();
-        },
-        updateActiveFileHighlight() {},
-        updateDocumentPanelTitle() {
-            const header = this.controllers?.header;
-            header?.updateDocumentPanelTitle();
-        },
-        buildQuery(params) {
-            return this.router ? this.router.buildQuery(params) : '';
-        },
-        updateLocation(file, options = {}) {
-            if (!this.router) {
-                return;
-            }
-            const { replace = false } = options;
-            if (replace) {
-                this.router.replace(file);
-            } else {
-                this.router.push(file);
-            }
-        },
+        sets: { expandedDirectories, knownDirectories },
+        applyHasPendingChanges,
+        setConnectionStatusHandler,
+        updateHeader: () => {},
+        updateActionVisibility: () => {},
+        updateDocumentPanelTitle: () => {},
+        buildQuery: () => '',
+        updateLocation: () => {},
         fallbackMarkdownFor,
-        normaliseFileIndex: (values) => normaliseFileIndex(values),
-        buildTreeFromFlatList: (list) => buildTreeFromFlatList(list),
-        getCssNumber: (variableName, fallback) => getCssNumber(rootElement, variableName, fallback),
-    };
+        normaliseFileIndex,
+        buildTreeFromFlatList,
+        getCssNumber,
+        rootElement,
+        setStatus,
+    });
     const markdownContext = {
         content,
         tocList,

--- a/tests/frontend/app/shared_context.test.mjs
+++ b/tests/frontend/app/shared_context.test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createSharedContext } from '../../../frontend/src/js/app/shared_context.js';
+
+// Helper to construct a shared context with overridable hooks for assertions.
+function createContext(overrides = {}) {
+    const appState = {
+        currentFile: null,
+        currentContent: '',
+        hasPendingChanges: false,
+        isEditing: false,
+        isPreviewing: false,
+        resolvedRootPath: '',
+        originalPathArgument: '',
+        files: [],
+        fileTree: [],
+    };
+
+    const elements = {
+        content: {},
+        fileName: {},
+        sidebarPath: {},
+        fileList: {},
+        downloadButton: {},
+        deleteButton: {},
+        editButton: {},
+        previewButton: {},
+        saveButton: {},
+        cancelButton: {},
+        editorContainer: {},
+        unsavedChangesModal: {},
+        unsavedChangesFilename: {},
+        unsavedChangesMessage: {},
+        unsavedChangesDetail: {},
+        unsavedChangesSaveButton: {},
+        unsavedChangesDiscardButton: {},
+        unsavedChangesCancelButton: {},
+    };
+
+    const sets = {
+        expandedDirectories: new Set(),
+        knownDirectories: new Set(),
+    };
+
+    const baseConfig = {
+        appState,
+        elements,
+        sets,
+        applyHasPendingChanges: () => {},
+        setConnectionStatusHandler: () => {},
+        updateHeader: () => {},
+        updateActionVisibility: () => {},
+        updateDocumentPanelTitle: () => {},
+        buildQuery: () => '',
+        updateLocation: () => {},
+        fallbackMarkdownFor: () => '',
+        normaliseFileIndex: (value) => value,
+        buildTreeFromFlatList: (value) => value,
+        getCssNumber: () => 0,
+        rootElement: {},
+        setStatus: () => {},
+    };
+
+    return {
+        appState,
+        sharedContext: createSharedContext({ ...baseConfig, ...overrides }),
+    };
+}
+
+test('setCurrentFile updates state and triggers injected callbacks', () => {
+    let headerCalls = 0;
+    let docTitleCalls = 0;
+    let highlightCalls = 0;
+
+    const { appState, sharedContext } = createContext({
+        updateHeader: () => {
+            headerCalls += 1;
+        },
+        updateDocumentPanelTitle: () => {
+            docTitleCalls += 1;
+        },
+    });
+
+    sharedContext.updateActiveFileHighlight = () => {
+        highlightCalls += 1;
+    };
+
+    sharedContext.setCurrentFile('README.md');
+
+    assert.equal(appState.currentFile, 'README.md');
+    assert.equal(headerCalls, 1, 'updateHeader should be called when file changes');
+    assert.equal(docTitleCalls, 1, 'updateDocumentPanelTitle should be called when file changes');
+    assert.equal(highlightCalls, 1, 'updateActiveFileHighlight should be called when file changes');
+
+    sharedContext.setCurrentFile('README.md', { silent: true });
+    assert.equal(headerCalls, 1, 'callbacks are not repeated when value does not change');
+});
+
+test('setHasPendingChanges uses injected applyHasPendingChanges when no header controller exists', () => {
+    const pendingValues = [];
+    const { appState, sharedContext } = createContext({
+        applyHasPendingChanges: (value) => {
+            pendingValues.push(value);
+        },
+    });
+
+    sharedContext.setHasPendingChanges(true);
+
+    assert.equal(appState.hasPendingChanges, true);
+    assert.deepEqual(pendingValues, [true]);
+});
+
+test('setHasPendingChanges prefers header controller when present', () => {
+    const pendingValues = [];
+    const headerValues = [];
+
+    const { appState, sharedContext } = createContext({
+        applyHasPendingChanges: (value) => {
+            pendingValues.push(value);
+        },
+    });
+
+    sharedContext.controllers.header = {
+        applyHasPendingChanges(value) {
+            headerValues.push(value);
+            appState.hasPendingChanges = Boolean(value);
+        },
+    };
+
+    sharedContext.setHasPendingChanges(true);
+
+    assert.equal(appState.hasPendingChanges, true);
+    assert.deepEqual(headerValues, [true]);
+    assert.deepEqual(pendingValues, [], 'fallback handler should not run when header is available');
+});


### PR DESCRIPTION
## Summary
- extract shared context setters/getters into a dedicated factory module
- update the unified bootstrap to build the shared context via the factory with injected callbacks
- add focused unit tests for the shared context and run them via the frontend test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e29c9767088328b4668675dafeaad7