### PR TITLE
Fix shared context editing toggle without this binding

### DIFF
--- a/frontend/src/js/app/shared_context.js
+++ b/frontend/src/js/app/shared_context.js
@@ -142,7 +142,12 @@ export function createSharedContext({
                 return;
             }
             appState.isEditing = next;
-            this.updateActionVisibility();
+            const header = this.controllers?.header;
+            if (typeof header?.updateActionVisibility === 'function') {
+                header.updateActionVisibility();
+            } else {
+                invokeUpdateActionVisibility();
+            }
         },
         isPreviewing: () => appState.isPreviewing,
         setPreviewing(value) {
@@ -151,7 +156,12 @@ export function createSharedContext({
                 return;
             }
             appState.isPreviewing = next;
-            this.updateActionVisibility();
+            const header = this.controllers?.header;
+            if (typeof header?.updateActionVisibility === 'function') {
+                header.updateActionVisibility();
+            } else {
+                invokeUpdateActionVisibility();
+            }
         },
         getResolvedRootPath: () => appState.resolvedRootPath,
         setResolvedRootPath(value) {


### PR DESCRIPTION
## Summary
- ensure editing and preview toggles directly invoke the action visibility update logic
- keep header controller logic intact even when the shared context methods are called unbound

## Testing
- npm test *(fails: missing optional dev dependency jsdom in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ab0069d08328876a2c270b0c38a8