### PR TITLE
Expand Highlight.js language support

### DIFF
--- a/frontend/src/js/vendor_globals.js
+++ b/frontend/src/js/vendor_globals.js
@@ -1,6 +1,8 @@
 import { marked } from 'marked';
 import { baseUrl as markedBaseUrlFn } from 'marked-base-url';
-import hljs from 'highlight.js/lib/common';
+// Import the full Highlight.js bundle so that all shipped languages are registered
+// (covering mainstream and less common languages such as C#, COBOL, Fortran, etc.).
+import hljs from 'highlight.js';
 import mermaid from 'mermaid';
 import * as dockview from 'dockview';
 import React from 'react';


### PR DESCRIPTION
## Summary
- load the full Highlight.js bundle so every shipped language is available for markdown rendering

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e39414c10883288e8a8f1d266918a2