### PR TITLE
Configure linting for backend and frontend

### DIFF
--- a/apps/backend/.eslintrc.json
+++ b/apps/backend/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "root": true,
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "no-console": "off"
+  }
+}

--- a/apps/frontend/.eslintrc.json
+++ b/apps/frontend/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "globals": {
+    "marked": "readonly",
+    "markedBaseUrl": "readonly",
+    "hljs": "readonly",
+    "mermaid": "readonly",
+    "vegaEmbed": "readonly",
+    "svelteCompilerGlobal": "readonly",
+    "svelteInternalGlobal": "readonly",
+    "svelteInstances": "readonly"
+  },
+  "rules": {
+    "no-console": "off"
+  },
+  "overrides": [
+    {
+      "files": ["tests/**/*.js"],
+      "env": {
+        "node": true
+      }
+    }
+  ]
+}

--- a/apps/frontend/src/js/editor/editor.js
+++ b/apps/frontend/src/js/editor/editor.js
@@ -18,7 +18,6 @@ export function initEditor(context, viewerApi, navigationApi) {
         setHasPendingChanges = () => {},
         getCurrentFile = () => null,
         getCurrentContent = () => '',
-        setCurrentContent = () => {},
         isEditing = () => false,
         setEditing = () => {},
         isPreviewing = () => false,

--- a/apps/frontend/src/js/unified_index.js
+++ b/apps/frontend/src/js/unified_index.js
@@ -47,20 +47,7 @@ function composeUnifiedApp() {
         unsavedChangesDiscardButton,
         unsavedChangesCancelButton,
         tocList,
-        tocSidebar,
-        fileSidebar,
-        tocSplitter,
-        fileSplitter,
-        dockviewRoot,
-        appShell,
         rootElement,
-        viewerSection,
-        terminalPanel,
-        terminalContainer,
-        terminalToggleButton,
-        terminalStatusText,
-        terminalResizeHandle,
-        panelToggleButtons,
     } = elements;
     const { expandedDirectories, knownDirectories } = sets;
 


### PR DESCRIPTION
## Summary
- add workspace-specific ESLint configurations for the backend and frontend packages
- declare browser and third-party globals while cleaning up unused destructured fields in the frontend bootstrap code
- tidy the editor context destructuring so linting no longer flags unused variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e39e6b42d08328916c3db7edf9b3c1