### PR TITLE
Handle backend terminal without native node-pty

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -50,6 +50,9 @@ the repository root.
 - A `ws` powered broadcast channel emits directory updates triggered by a
   `chokidar` watcher. Watchers are reference counted so they are released when
   the last websocket subscriber disconnects.
-- Terminal support is implemented with `node-pty`, delivering behaviour on par
-  with the retired asyncio variant while remaining extensible for future
-  hardening.
+- Terminal support prefers `node-pty` when the optional dependency is
+  available. When it cannot be compiled (common on fresh Windows
+  environments) the server transparently falls back to a plain
+  `child_process` transport so `npm install` succeeds without native
+  toolchains. Installing `node-pty` manually restores the richer TTY
+  experience.

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -18,12 +18,14 @@
   "dependencies": {
     "chokidar": "^3.5.3",
     "express": "^4.19.2",
-    "node-pty": "^1.0.0",
     "ws": "^8.15.1",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
     "supertest": "^6.3.4",
     "vitest": "^1.6.0"
+  },
+  "optionalDependencies": {
+    "node-pty": "^1.0.0"
   }
 }

--- a/apps/backend/src/server.js
+++ b/apps/backend/src/server.js
@@ -6,9 +6,9 @@ import { fileURLToPath } from 'url';
 import chokidar from 'chokidar';
 import express from 'express';
 import { WebSocket, WebSocketServer } from 'ws';
-import pty from 'node-pty';
 
 import { FileManager } from './fileManager.js';
+import { createTerminal } from './terminal.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -86,7 +86,9 @@ export class UnifiedMarkdownServer {
     });
 
     directorySocket.on('connection', (ws) => this.#handleDirectorySocket(ws));
-    terminalSocket.on('connection', (ws) => this.#handleTerminalSocket(ws));
+    terminalSocket.on('connection', (ws) => {
+      this.#handleTerminalSocket(ws);
+    });
 
     server.listen(this.port, () => {
       // eslint-disable-next-line no-console
@@ -454,16 +456,15 @@ export class UnifiedMarkdownServer {
     });
   }
 
-  #handleTerminalSocket(ws) {
-    // node-pty gives us a stable pseudo-terminal similar to the Python pty.fork logic.
-    const shell = process.env.SHELL || 'bash';
-    const term = pty.spawn(shell, [], {
-      name: 'xterm-color',
-      cols: 80,
-      rows: 30,
-      cwd: process.cwd(),
-      env: process.env,
-    });
+  async #handleTerminalSocket(ws) {
+    let term;
+    try {
+      term = await createTerminal({ cols: 80, rows: 30, cwd: process.cwd(), env: process.env });
+    } catch (error) {
+      ws.send(JSON.stringify({ type: 'state', message: `Failed to start shell: ${error.message}` }));
+      ws.close(1011, 'Terminal unavailable');
+      return;
+    }
 
     term.onData((data) => {
       if (ws.readyState === WebSocket.OPEN) {
@@ -471,7 +472,24 @@ export class UnifiedMarkdownServer {
       }
     });
 
-    ws.send(JSON.stringify({ type: 'state', message: 'Shell ready' }));
+    term.onExit(({ code, signal }) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        const details =
+          typeof code === 'number' || signal
+            ? ` (code: ${code ?? 'null'}${signal ? `, signal: ${signal}` : ''})`
+            : '';
+        ws.send(
+          JSON.stringify({
+            type: 'state',
+            message: `Shell exited${details}`,
+          }),
+        );
+        ws.close(1000, 'Shell exited');
+      }
+    });
+
+    const backendLabel = term.backend === 'node-pty' ? 'pty' : 'stdio';
+    ws.send(JSON.stringify({ type: 'state', message: `Shell ready (${backendLabel})` }));
 
     ws.on('message', (raw) => {
       let payload;

--- a/apps/backend/src/terminal.js
+++ b/apps/backend/src/terminal.js
@@ -1,0 +1,112 @@
+import { spawn } from 'child_process';
+
+function detectDefaultShell() {
+  if (process.platform === 'win32') {
+    return process.env.COMSPEC || 'cmd.exe';
+  }
+  return process.env.SHELL || 'bash';
+}
+
+function normalizeText(chunk) {
+  return typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+}
+
+function createSpawnTerminal({ shell, cwd, env }) {
+  const child = spawn(shell, [], {
+    cwd,
+    env,
+    stdio: 'pipe',
+    windowsHide: process.platform === 'win32',
+  });
+
+  child.stdin.setDefaultEncoding('utf8');
+
+  const dataHandlers = new Set();
+
+  const forwardChunk = (chunk) => {
+    const text = normalizeText(chunk);
+    for (const handler of dataHandlers) {
+      handler(text);
+    }
+  };
+
+  child.stdout?.on('data', forwardChunk);
+  child.stderr?.on('data', forwardChunk);
+
+  return {
+    backend: 'child_process',
+    onData(handler) {
+      dataHandlers.add(handler);
+    },
+    onExit(handler) {
+      child.on('exit', (code, signal) => {
+        handler({ code, signal });
+      });
+    },
+    write(data) {
+      if (!child.killed) {
+        child.stdin.write(data);
+      }
+    },
+    resize() {
+      // The raw child process transport cannot be resized, but callers expect the method.
+    },
+    kill() {
+      if (!child.killed) {
+        child.kill();
+      }
+    },
+  };
+}
+
+async function tryLoadNodePty() {
+  try {
+    const module = await import('node-pty');
+    return module?.default ?? module;
+  } catch (error) {
+    if (error && error.code !== 'ERR_MODULE_NOT_FOUND') {
+      // eslint-disable-next-line no-console
+      console.warn('Failed to load optional dependency node-pty. Falling back to child_process:', error);
+    }
+    return undefined;
+  }
+}
+
+export async function createTerminal({
+  shell = detectDefaultShell(),
+  cols = 80,
+  rows = 30,
+  cwd = process.cwd(),
+  env = process.env,
+} = {}) {
+  const nodePty = await tryLoadNodePty();
+  if (nodePty) {
+    const term = nodePty.spawn(shell, [], {
+      name: 'xterm-color',
+      cols,
+      rows,
+      cwd,
+      env,
+    });
+    return {
+      backend: 'node-pty',
+      onData(handler) {
+        term.onData(handler);
+      },
+      onExit(handler) {
+        term.onExit(({ exitCode, signal }) => handler({ code: exitCode, signal }));
+      },
+      write(data) {
+        term.write(data);
+      },
+      resize(nextCols, nextRows) {
+        term.resize(nextCols, nextRows);
+      },
+      kill() {
+        term.kill();
+      },
+    };
+  }
+
+  return createSpawnTerminal({ shell, cwd, env });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,13 +24,15 @@
       "dependencies": {
         "chokidar": "^3.5.3",
         "express": "^4.19.2",
-        "node-pty": "^1.0.0",
         "ws": "^8.15.1",
         "yargs": "^17.7.2"
       },
       "devDependencies": {
         "supertest": "^6.3.4",
         "vitest": "^1.6.0"
+      },
+      "optionalDependencies": {
+        "node-pty": "^1.0.0"
       }
     },
     "apps/frontend": {
@@ -4873,7 +4875,8 @@
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
       "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -4958,6 +4961,7 @@
       "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "nan": "^2.17.0"
       }


### PR DESCRIPTION
## Summary
- add a terminal helper that prefers node-pty but gracefully falls back to child_process when the module is unavailable
- update the websocket terminal bridge to use the helper and surface status messages to clients
- mark node-pty as optional and document the fallback so npm install succeeds on Windows without build tools

## Testing
- npm test --workspace asynkron-liveview-backend
- npm run lint --workspace asynkron-liveview-backend

------
https://chatgpt.com/codex/tasks/task_e_68e620819f0c8328aef5d447aa4e87e0